### PR TITLE
Renamed ProductProvider protocol functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * AutoLayout-Helper Dependencies - Moved function in the SDK
 
 ### Changed
+* renamed ProductProvider functions by removing unnamed (underscore) arguments
 
 ### Updated
 

--- a/Sources/Core/Cart/CartData.swift
+++ b/Sources/Core/Cart/CartData.swift
@@ -116,7 +116,7 @@ public struct CartItem: Codable {
 
     /// init with a freshly retrieved copy of `item.product`.
     init?(updating item: CartItem, _ provider: ProductProvider, _ shopId: Identifier<Shop>, _ customerCard: String?) {
-        guard let product = provider.productBySku(item.product.sku, shopId) else {
+        guard let product = provider.productBy(sku: item.product.sku, shopId: shopId) else {
             return nil
         }
 

--- a/Sources/Core/Products/ProductDB+Lookup.swift
+++ b/Sources/Core/Products/ProductDB+Lookup.swift
@@ -110,7 +110,7 @@ extension ProductDB {
         }
     }
 
-    func resolveProductLookup(_ url: String, _ sku: String, _ shopId: Identifier<Shop>, completion: @escaping (_ result: Result<Product, ProductLookupError>) -> Void) {
+    func resolveProductLookup(url: String, sku: String, shopId: Identifier<Shop>, completion: @escaping (_ result: Result<Product, ProductLookupError>) -> Void) {
         let session = Snabble.urlSession
 
         // TODO: is this the right value?

--- a/Sources/Core/Products/ProductDB.swift
+++ b/Sources/Core/Products/ProductDB.swift
@@ -757,7 +757,7 @@ extension ProductDB {
             return nil
         }
 
-        return self.productBySku(db, sku, shopId)
+        return self.productBy(db, sku: sku, shopId: shopId)
     }
 
     /// get a list of products by their SKUs
@@ -771,7 +771,7 @@ extension ProductDB {
             return []
         }
 
-        return self.productsBySku(db, skus, shopId)
+        return self.productsBy(db, skus: skus, shopId: shopId)
     }
 
     /// get a product by one of its scannable codes/template pairs
@@ -780,7 +780,7 @@ extension ProductDB {
             return nil
         }
 
-        return self.productByScannableCodes(db, codes, shopId)
+        return self.productBy(db, codes: codes, shopId: shopId)
     }
 
     /// get products matching `name`
@@ -800,7 +800,7 @@ extension ProductDB {
             Log.warn("productsByName called, but useFTS not set")
         }
 
-        return self.productsByName(db, name, filterDeposits, "")
+        return self.productsBy(db, name: name, filterDeposits: filterDeposits, shopId: "")
     }
 
     ///
@@ -815,7 +815,7 @@ extension ProductDB {
             return []
         }
 
-        return self.productsByScannableCodePrefix(db, prefix, filterDeposits, templates, shopId)
+        return self.productsBy(db, prefix: prefix, filterDeposits: filterDeposits, templates: templates, shopId: shopId)
     }
 
     // MARK: - asynchronous requests

--- a/Sources/UI/Scanner/BarcodeEntryViewController.swift
+++ b/Sources/UI/Scanner/BarcodeEntryViewController.swift
@@ -116,10 +116,10 @@ extension BarcodeEntryViewController: UISearchBarDelegate {
     // MARK: - search bar
     public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         if !searchText.isEmpty {
-            let products = self.productProvider?.productsByScannableCodePrefix(searchText,
-                                                                              filterDeposits: true,
-                                                                              templates: SnabbleCI.project.searchableTemplates,
-                                                                              shopId: self.shopId)
+            let products = self.productProvider?.productsBy(prefix: searchText,
+                                                            filterDeposits: true,
+                                                            templates: SnabbleCI.project.searchableTemplates,
+                                                            shopId: self.shopId)
             self.filteredProducts = removeDuplicates(products ?? []).sorted { prod1, prod2 in
                 let code1 = prod1.codes.filter { $0.code.hasPrefix(searchText) }.first ?? prod1.codes.first!
                 let code2 = prod2.codes.filter { $0.code.hasPrefix(searchText) }.first ?? prod2.codes.first!

--- a/Sources/UI/Scanner/ScanningViewController.swift
+++ b/Sources/UI/Scanner/ScanningViewController.swift
@@ -586,7 +586,7 @@ extension ScanningViewController {
         let templates = matches.map { $0.template.id }
         let codes = Array(zip(lookupCodes, templates))
 
-        self.productProvider.productByScannableCodes(codes, self.shop.id) { result in
+        self.productProvider.productBy(codes: codes, shopId: self.shop.id) { result in
             switch result {
             case .success(let lookupResult):
                 guard let parseResult = matches.first(where: { $0.template.id == lookupResult.templateId }) else {
@@ -687,7 +687,7 @@ extension ScanningViewController {
         }
 
         let codes = [(gtin, CodeTemplate.defaultName)]
-        self.productProvider.productByScannableCodes(codes, self.shop.id) { result in
+        self.productProvider.productBy(codes: codes, shopId: self.shop.id) { result in
             switch result {
             case .success(let lookupResult):
                 let priceDigits = SnabbleCI.project.decimalDigits
@@ -727,7 +727,7 @@ extension ScanningViewController {
         let lookupCodes = matches.map { $0.lookupCode }
         let templates = matches.map { $0.template.id }
         let codes = Array(zip(lookupCodes, templates))
-        self.productProvider.productByScannableCodes(codes, self.shop.id) { result in
+        self.productProvider.productBy(codes: codes, shopId: self.shop.id) { result in
             switch result {
             case .success(let lookupResult):
                 let newResult = ScannedProduct(lookupResult.product, code, match.transmissionCode,
@@ -746,7 +746,7 @@ extension ScanningViewController {
 
     private func lookupProduct(for code: String, withTemplate template: String, priceOverride: Int?, completion: @escaping (ScannerLookup) -> Void ) {
         let codes = [(code, template)]
-        self.productProvider.productByScannableCodes(codes, self.shop.id) { result in
+        self.productProvider.productBy(codes: codes, shopId: self.shop.id) { result in
             switch result {
             case .success(let lookupResult):
                 let transmissionCode = lookupResult.product.codes[0].transmissionCode

--- a/Sources/UI/ShoppingCart/ShoppingCartTableViewController.swift
+++ b/Sources/UI/ShoppingCart/ShoppingCartTableViewController.swift
@@ -201,7 +201,7 @@ final class ShoppingCartTableViewController: UITableViewController {
                 // propagate the change to the shopping cart
                 if let lineItem = items.first, items.count == 1, let sku = lineItem.sku, sku != cartItem.product.sku {
                     let provider = Snabble.shared.productProvider(for: SnabbleCI.project)
-                    let product = provider.productBySku(sku, self.shoppingCart.shopId)
+                    let product = provider.productBy(sku: sku, shopId: self.shoppingCart.shopId)
                     if let product = product, let replacement = CartItem(replacing: cartItem, product, self.shoppingCart.shopId, lineItem) {
                         cart.replaceItem(at: index, with: replacement)
                     } else {
@@ -487,7 +487,7 @@ extension ShoppingCartTableViewController {
 
             group.enter()
 
-            provider.productBySku(sku, self.shoppingCart.shopId) { result in
+            provider.productBy(sku: sku, shopId: self.shoppingCart.shopId) { result in
                 switch result {
                 case .failure(let error):
                     Log.error("error in pending lookup for \(sku): \(error)")

--- a/Tests/Core/MockProducts.swift
+++ b/Tests/Core/MockProducts.swift
@@ -117,15 +117,15 @@ class MockProductDB: ProductProvider {
 
     func stopDatabaseUpdate() {}
 
-    func productBySku(_ sku: String, _ shopId: Identifier<Shop>) -> Product? {
+    func productBy(sku: String, shopId: Identifier<Shop>) -> Product? {
         return MockProductDB.productMap[sku]
     }
 
-    func productByScannableCodes(_ codes: [(String, String)], _ shopId: Identifier<Shop>) -> ScannedProduct? {
+    func productBy(codes: [(String, String)], shopId: Identifier<Shop>) -> ScannedProduct? {
         return nil
     }
 
-    func productsBySku(_ skus: [String], _ shopId: Identifier<Shop>) -> [Product] {
+    func productsBy(skus: [String], shopId: Identifier<Shop>) -> [Product] {
         var products = [Product]()
         skus.forEach {
             if let p = MockProductDB.productMap[$0] {
@@ -135,12 +135,12 @@ class MockProductDB: ProductProvider {
         return products
     }
 
-    func productsByName(_ name: String, filterDeposits: Bool) -> [Product] {
+    func productsBy(name: String, filterDeposits: Bool) -> [Product] {
         let products = MockProductDB.allProducts.filter { $0.name.contains(name) }
         return products
     }
 
-    func productsByScannableCodePrefix(_ prefix: String, filterDeposits: Bool, templates: [String]?, shopId: Identifier<Shop>) -> [Product] {
+    func productsBy(prefix: String, filterDeposits: Bool, templates: [String]?, shopId: Identifier<Shop>) -> [Product] {
         let products = MockProductDB.allProducts.filter { product in
             let matches = product.codes.filter { $0.template == "default" && $0.code.hasPrefix(prefix) }
             return matches.count > 0
@@ -152,11 +152,11 @@ class MockProductDB: ProductProvider {
         }
     }
 
-    func productBySku(_ sku: String, _ shopId: Identifier<Shop>, forceDownload: Bool, completion: @escaping (Result<Product, ProductLookupError>) -> ()) {
+    func productBy(sku: String, shopId: Identifier<Shop>, forceDownload: Bool, completion: @escaping (Result<Product, ProductLookupError>) -> ()) {
         completion(Result.failure(.notFound))
     }
 
-    func productByScannableCodes(_ codes: [(String, String)], _ shopId: Identifier<Shop>, forceDownload: Bool, completion: @escaping (Result<ScannedProduct, ProductLookupError>) -> ()) {
+    func productBy(codes: [(String, String)], shopId: Identifier<Shop>, forceDownload: Bool, completion: @escaping (Result<ScannedProduct, ProductLookupError>) -> ()) {
         completion(Result.failure(.notFound))
     }
 

--- a/Tests/Core/SnabbleTests.swift
+++ b/Tests/Core/SnabbleTests.swift
@@ -66,96 +66,96 @@ class SnabbleTests: XCTestCase {
         NSLog("start db tests")
         let shopId: Identifier<Shop> = "8"
 
-        XCTAssertNil(pdb.productBySku("1234", shopId), "unexpected product found")
-        XCTAssertNotNil(pdb.productBySku("22", shopId), "sku 22 not found")
+        XCTAssertNil(pdb.productBy(sku: "1234", shopId: shopId), "unexpected product found")
+        XCTAssertNotNil(pdb.productBy(sku: "22", shopId: shopId), "sku 22 not found")
 
-        var products = pdb.productsBySku(["1234","5678"], shopId)
+        var products = pdb.productsBy(skus: ["1234","5678"], shopId: shopId)
         XCTAssertEqual(products.count, 0, "unexpected product found")
-        products = pdb.productsBySku(["22","23"], shopId)
+        products = pdb.productsBy(skus: ["22","23"], shopId: shopId)
         XCTAssertEqual(products.count, 2, "skus 22+23 not found")
 
-        XCTAssertNil(pdb.productByScannableCodes([("1234", "default")], shopId), "unexpected product found")
-        XCTAssertNotNil(pdb.productByScannableCodes([("0885580466671", "default")], shopId), "ean 0885580466671 not found")
+        XCTAssertNil(pdb.productBy(codes: [("1234", "default")], shopId: shopId), "unexpected product found")
+        XCTAssertNotNil(pdb.productBy(codes: [("0885580466671", "default")], shopId: shopId), "ean 0885580466671 not found")
 
-        XCTAssertNotNil(pdb.productByScannableCodes([("0885580466671", "default"), ("0885580466671", "ean13_instore"), ("0885580466671", "ean13_instore_chk") ], shopId), "ean 0885580466671 not found")
+        XCTAssertNotNil(pdb.productBy(codes: [("0885580466671", "default"), ("0885580466671", "ean13_instore"), ("0885580466671", "ean13_instore_chk") ], shopId: shopId), "ean 0885580466671 not found")
 
-        XCTAssertNotNil(pdb.productByScannableCodes([("32323", "ean13_instore_chk")], shopId), "weightItem XYZ not found")
+        XCTAssertNotNil(pdb.productBy(codes: [("32323", "ean13_instore_chk")], shopId: shopId), "weightItem XYZ not found")
 
         let hoodies = pdb.productsByName("hoodie")
         XCTAssertTrue(hoodies.count > 0, "no hoodies found")
         if hoodies.count > 0 {
-            XCTAssertNotNil(pdb.productBySku(hoodies[0].sku, shopId), "sku lookup fail")
-            XCTAssertNotNil(pdb.productByScannableCodes([(hoodies[0].codes.first!.code, "default")], shopId), "ean lookup fail")
+            XCTAssertNotNil(pdb.productBy(sku: hoodies[0].sku, shopId: shopId), "sku lookup fail")
+            XCTAssertNotNil(pdb.productBy(codes: [(hoodies[0].codes.first!.code, "default")], shopId: shopId), "ean lookup fail")
         }
 
         // check for codes beginning with 4 - there should be some
-        let prefix4 = pdb.productsByScannableCodePrefix("4", "")
+        let prefix4 = pdb.productsBy(prefix: "4", shopId: "")
         XCTAssertTrue(prefix4.count > 0, "ean prefix fail")
 
         // check for codes beginning with 5 - there should be none, due to records in `availabilities`
-        let prefix5 = pdb.productsByScannableCodePrefix("5", "").filter { !$0.sku.hasPrefix("5") }
+        let prefix5 = pdb.productsBy(prefix: "5", shopId: "").filter { !$0.sku.hasPrefix("5") }
         XCTAssertEqual(prefix5.count, 0, "ean prefix fail")
 
-        let prod = pdb.productBySku("50", shopId)
+        let prod = pdb.productBy(sku: "50", shopId: shopId)
         XCTAssertNotNil(prod)
         XCTAssertEqual(prod?.codes.count, 2)
 
-        let prod1 = pdb.productByScannableCodes([("40084015", "default")], shopId)
+        let prod1 = pdb.productBy(codes: [("40084015", "default")], shopId: shopId)
         XCTAssertNotNil(prod1)
         XCTAssertEqual(prod1?.product.codes.count, 2)
         XCTAssertEqual(prod1?.transmissionCode, nil)
 
-        let prod2 = pdb.productByScannableCodes([("0000040084015", "default")], shopId)
+        let prod2 = pdb.productBy(codes: [("0000040084015", "default")], shopId: shopId)
         XCTAssertNotNil(prod2)
         XCTAssertEqual(prod2?.product.codes.count, 2)
         XCTAssertEqual(prod2?.transmissionCode, "40084015")
 
-        pdb.productBySku("22", shopId, forceDownload: true) { result in
+        pdb.productBy(sku: "22", shopId: shopId, forceDownload: true) { result in
             self.assertOk(result, "d/l product by sku failed")
             expectation.fulfill()
         }
 
-        pdb.productBySku("1234", shopId, forceDownload: true) { result in
+        pdb.productBy(sku: "1234", shopId: shopId, forceDownload: true) { result in
             self.assertError(result, "unexpected product")
             expectation.fulfill()
         }
 
-        pdb.productByScannableCodes([("0885580466671", "default")], shopId) { result in
+        pdb.productBy(codes: [("0885580466671", "default")], shopId: shopId) { result in
             self.assertOk(result, "d/l product by ean failed")
             expectation.fulfill()
         }
 
-        pdb.productByScannableCodes([("1234", "default")], shopId) { result in
+        pdb.productBy(codes: [("1234", "default")], shopId: shopId) { result in
             self.assertError(result, "unexpected product")
             expectation.fulfill()
         }
 
-        pdb.productByScannableCodes([("0885580466671", "default")], shopId, forceDownload: true) { result in
+        pdb.productBy(codes: [("0885580466671", "default")], shopId: shopId, forceDownload: true) { result in
             self.assertOk(result, "d/l product by ean failed")
             expectation.fulfill()
         }
 
-        pdb.productByScannableCodes([("0885580466671", "default"),("0885580466671", "ean13_instore"),("0885580466671", "ean13_instore_chk")], shopId, forceDownload: true) { result in
+        pdb.productBy(codes: [("0885580466671", "default"),("0885580466671", "ean13_instore"),("0885580466671", "ean13_instore_chk")], shopId: shopId, forceDownload: true) { result in
             self.assertOk(result, "d/l product by ean failed")
             expectation.fulfill()
         }
 
-        pdb.productByScannableCodes([("1234", "default")], shopId, forceDownload: true) { result in
+        pdb.productBy(codes: [("1234", "default")], shopId: shopId, forceDownload: true) { result in
             self.assertError(result, "unexpected product")
             expectation.fulfill()
         }
 
-//        pdb.productByScannableCodes([("32323", "ean13_instore_chk")], shopId, forceDownload: true) { result in
+//        pdb.productBy(codes: [("32323", "ean13_instore_chk")], shopId, forceDownload: true) { result in
 //            self.assertOk(result, "d/l product by weighId failed")
 //            expectation.fulfill()
 //        }
 
-        pdb.productByScannableCodes([("1234", "ean13_instore_chk")], shopId, forceDownload: true) { result in
+        pdb.productBy(codes: [("1234", "ean13_instore_chk")], shopId: shopId, forceDownload: true) { result in
             self.assertError(result, "unexpected product")
             expectation.fulfill()
         }
 
-        pdb.productBySku("37", shopId, forceDownload: false) { result in
+        pdb.productBy(sku: "37", shopId: shopId, forceDownload: false) { result in
             self.assertOk(result, "no product")
             switch result {
             case .success(let product):
@@ -169,7 +169,7 @@ class SnabbleTests: XCTestCase {
             expectation.fulfill()
         }
 
-        pdb.productBySku("37", shopId, forceDownload: true) { result in
+        pdb.productBy(sku: "37", shopId: shopId, forceDownload: true) { result in
             self.assertOk(result, "no product")
             switch result {
             case .success(let product):
@@ -183,7 +183,7 @@ class SnabbleTests: XCTestCase {
             expectation.fulfill()
         }
 
-        pdb.productBySku("salfter-classic", "177", forceDownload: true) { result in
+        pdb.productBy(sku: "salfter-classic", shopId: "177", forceDownload: true) { result in
             self.assertOk(result, "no product")
             switch result {
             case .success(let product):
@@ -193,7 +193,7 @@ class SnabbleTests: XCTestCase {
             expectation.fulfill()
         }
 
-        pdb.productBySku("salfter-classic", "1775", forceDownload: true) { result in
+        pdb.productBy(sku: "salfter-classic", shopId: "1775", forceDownload: true) { result in
             self.assertOk(result, "no product")
             switch result {
             case .success(let product):


### PR DESCRIPTION
I have removed all underscores for product lookup functions. 
Examples: 
```
func productBySku(_ sku: String, _ shopId: Identifier<Shop>) -> Product?
func productByScannableCodes(_ codes: [(String, String)], _ shopId: Identifier<Shop>) -> ScannedProduct?

```
are renamed to:
```
func productBy(sku: String, shopId: Identifier<Shop>) -> Product?
func productBy(codes: [(String, String)], shopId: Identifier<Shop>) -> ScannedProduct?

```