### PR TITLE
SwiftLint in Strict Mode on GitHub Actions

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,7 +18,7 @@ jobs:
       - name: SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1
         with:
-          args: --config .swiftlint.yml 
+          args: --config .swiftlint.yml --strict
 
       - name: Danger
         uses: danger/swift@3.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+* SwiftLint Strict Mode on GitHub Actions
+
 ## [0.24.0] - 2022-12-02
 
 ### Added

--- a/Sources/Core/Cart/CheckoutData.swift
+++ b/Sources/Core/Cart/CheckoutData.swift
@@ -129,7 +129,6 @@ public struct CheckoutInfo: Decodable {
     }
 
     public struct Violation: Codable {
-        // swiftlint:disable:next type_name
         public enum `Type`: String, Codable, UnknownCaseRepresentable {
             public static var unknownCase: Self = .unknown
 


### PR DESCRIPTION
* Lint Warnings should be considered as error on github actions

Falls wir die Linter Warnings in Pull Request ignorieren können wir ihn abschaffen. Ich würde ihn gerne weiterhin nutzen, aber es macht für mich nur Sinn wenn wir es auch nutzen. Daher die Fragen ob wir es nutzen wollen und wenn ja würde ich den `strict` mode auf GitHub empfehlen, damit wir die Warnings nicht ignorieren können.
