### PR TITLE
update attributes after changelog moved

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-documentation/Changelog.md -text merge=union
+CHANGELOG.md -text merge=union


### PR DESCRIPTION
Wir haben vergessen die attributes anzupassen als wir die Changelog bewegt haben.