### PR TITLE
APPS-623 unable to scan small barcodes on special devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * CoreProviding protocol to enable control of merging cart items. #APPS-597
 
 ### Fixed
-* Use a default barcode width to calculate a camera zoom factor
+* Use a default barcode width to calculate a camera zoom factor #APPS-623
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * CoreProviding protocol to enable control of merging cart items. #APPS-597
 
 ### Fixed
+* Use a default barcode width to calculate a camera zoom factor
 
 ### Removed
 

--- a/Sources/UI/Scanner/BuiltinBarcodeDetector.swift
+++ b/Sources/UI/Scanner/BuiltinBarcodeDetector.swift
@@ -186,10 +186,7 @@ public final class BuiltinBarcodeDetector: BarcodeDetector {
 
     @available(iOS 15, *)
     private func setRecommendedZoomFactor() {
-        guard
-            let videoInput = self.videoInput,
-            let expectedBarcodeWidth = self.expectedBarcodeWidth
-        else {
+        guard let videoInput = self.videoInput else {
             return
         }
 

--- a/Sources/UI/Scanner/RecommendedZoom.swift
+++ b/Sources/UI/Scanner/RecommendedZoom.swift
@@ -22,17 +22,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 @available(iOS 15, *)
 public enum RecommendedZoom {
-    public static func factor(for videoInput: AVCaptureDeviceInput, codeWidth: Int) -> Float {
+    public static var defaultBarcodeWidth: Int { 50 }
+
+    public static func factor(for videoInput: AVCaptureDeviceInput, codeWidth: Int?) -> Float {
         let deviceMinimumFocusDistance = Float(videoInput.device.minimumFocusDistance)
         guard deviceMinimumFocusDistance != -1 else {
             return 1
         }
 
         let deviceFieldOfView = videoInput.device.activeFormat.videoFieldOfView
-        let minimumSubjectDistanceForCode = minimumSubjectDistanceForCode(fieldOfView: deviceFieldOfView, width: codeWidth)
+        let minimumSubjectDistanceForCode = minimumSubjectDistanceForCode(fieldOfView: deviceFieldOfView, width: codeWidth ?? defaultBarcodeWidth)
         if minimumSubjectDistanceForCode < deviceMinimumFocusDistance {
             let zoomFactor = deviceMinimumFocusDistance / minimumSubjectDistanceForCode
-            return zoomFactor
+            return min(zoomFactor, Float(videoInput.device.maxAvailableVideoZoomFactor))
         }
         return 1
     }


### PR DESCRIPTION
Use a default barcode width to calculate a camera zoom factor