### PR TITLE
APPS-638 Hotspot helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
-* Use of https://captive.apple.com to check for captive portals
+* Use of https://captive.apple.com to check for captive portals #APPS-638
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+* Use of https://captive.apple.com to check for captive portals
 
 ### Removed
 

--- a/Sources/UI/DynamicView/WidgetConnectWifiView.swift
+++ b/Sources/UI/DynamicView/WidgetConnectWifiView.swift
@@ -79,9 +79,14 @@ final class ConnectWifiViewModel: ObservableObject {
 
             // after a short delay, try to access an url in the hope that
             // this forces any captive portal login screens to appear
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                let testURL = URL(string: "https://httpbin.org/status/200")!
-                let captiveTask = URLSession.shared.dataTask(with: testURL) { _, response, _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                let testURL = URL(string: "https://captive.apple.com")!
+                let captiveTask = URLSession.shared.dataTask(with: testURL) { _, response, error in
+                    if error != nil {
+                        DispatchQueue.main.async {
+                            self?.networkError = error
+                        }
+                    }
                     let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
                     print("got statuscode \(statusCode) from \(testURL)")
                 }


### PR DESCRIPTION
usage of https://captive.apple.com to check for captive portals
error handling on URLRequest