### PR TITLE
APPS-593 IBAN formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Add documentation to used secrets APPS-544
 * Add PayOne SEPA data transfer for payment with GiroCard at the SCO #APPS-612
+* Add PayOne SEPA formatter to enter IBANs in a human readable format #APPS-593
 
 ### Fixed
 

--- a/Sources/Core/Payment/IBAN.swift
+++ b/Sources/Core/Payment/IBAN.swift
@@ -98,14 +98,14 @@ public enum IBAN {
         "SM": (27, ["1!a", "5!n", "5!n", "12!c"], "pp Kbbb bbss sssk kkkk kkkk kkk"),
         "VA": (22, ["3!n", "15!n"], "pp bbbk kkkk kkkk kkkk kk")
     ]
-    
+
     public enum ControlChar: String {
         case digits = "n"
         case uppercaseLetters = "a"
         case alphanumerics = "c"
         case space = "e"
     }
-    
+
     public static func keyboardMapping(_ country: String) -> String {
         guard let mapping = self.info[country]?.mapping, let length = length(country) else {
             fatalError("invalid country: \(country)")
@@ -136,14 +136,14 @@ public enum IBAN {
         let pretty = IBAN.prettyPrint(string)
         return String(pretty.suffix(pretty.count - 2))
     }
-    
+
     public static let formatCharacters: [Character] = ["p", "b", "d", "k", "K", "r", "s", "X"]
     public static var formatKeys: String = { formatCharacters.reduce("", { "\($0)\($1)" } ) }()  // "pbdkKrsX"
-    
+
     public static var formatCharacterSet: CharacterSet {
         return CharacterSet(charactersIn: formatKeys)
     }
-    
+
     public static func formatString(_ country: String) -> String {
         guard let string = self.info[country]?.format, let length = length(country) else {
             fatalError("invalid country: \(country)")
@@ -159,15 +159,15 @@ public enum IBAN {
         }
         return result
     }
-    
+
     public static var countries: [String] {
         return info.keys.compactMap({ $0 })
     }
-    
+
     public static func length(_ country: String) -> Int? {
         return info[country]?.length
     }
-    
+
     public static func displayName(_ iban: String) -> String {
         let country = String(iban.prefix(2))
         let prefix = String(iban.prefix(4))
@@ -184,7 +184,7 @@ public enum IBAN {
 
         return prefix + String(placeholder[start..<end]) + suffix
     }
-    
+
     public static func validCharacterSet(_ country: String) -> CharacterSet {
         var charset = CharacterSet(charactersIn: "0123456789 ")
         
@@ -196,7 +196,6 @@ public enum IBAN {
         if mapping.contains(where: { $0 == Character(ControlChar.alphanumerics.rawValue) }) {
             charset.formUnion(.alphanumerics)
         }
-        
         return charset
     }
 
@@ -230,17 +229,17 @@ extension IBAN {
         let iban = iban.replacingOccurrences(of: " ", with: "")
         let country = String(iban.prefix(2))
         let placeholder = IBAN.placeholder(country)
-        
+
         guard placeholder.replacingOccurrences(of: " ", with: "").count == iban.count - 2 else {
             return iban
         }
-        
+
         var offset: Int = 4
         let prefix = String(iban.prefix(offset))
-        
+
         let start = placeholder.index(placeholder.startIndex, offsetBy: 2)
         var result = prefix
-        
+
         for char in String(placeholder[start...]) {
             if char == " " {
                 result.append(" ")
@@ -250,7 +249,6 @@ extension IBAN {
                 offset += 1
             }
         }
-        
         return result
     }
 }
@@ -260,10 +258,10 @@ public struct IBANDefinition {
     public let formatString: String
     public let placeholder: String
     public let keyboardMapping: String
-    
+
     public init(country: String) {
         self.country = country
-        
+
         self.formatString = IBAN.formatString(country)
         self.placeholder = IBAN.placeholder(country)
         self.keyboardMapping = IBAN.keyboardMapping(country)

--- a/Sources/Core/Payment/IBAN.swift
+++ b/Sources/Core/Payment/IBAN.swift
@@ -22,7 +22,6 @@ extension String {
 // DE75512108001245126199
 // NL02ABNA0123456789
 
-
 /**
  Supported official IBAN (ISO 13616) formats see:
  https://de.wikipedia.org/wiki/Internationale_Bankkontonummer#IBAN-Struktur_in_verschiedenen_Ländern
@@ -57,6 +56,7 @@ extension String {
  */
 
 public enum IBAN {
+    // swiftlint:disable large_tuple
     private static let info: [String: (length: Int, mapping: [String], format: String)] = [
         "AD": (24, ["4!n", "4!n", "12!c"], "pp bbbb ssss kkkk kkkk kkkk"),
         "AT": (20, ["5!n", "11!n"], "pp bbbb bkkk kkkk kkkk"),
@@ -98,6 +98,7 @@ public enum IBAN {
         "SM": (27, ["1!a", "5!n", "5!n", "12!c"], "pp Kbbb bbss sssk kkkk kkkk kkk"),
         "VA": (22, ["3!n", "15!n"], "pp bbbk kkkk kkkk kkkk kk")
     ]
+    // swiftlint:enable large_tuple
 
     public enum ControlChar: String {
         case digits = "n"
@@ -116,7 +117,7 @@ public enum IBAN {
         for item in mapping {
             func split() -> (count: Int, control: ControlChar)? {
                 if let countIndex = item.firstIndexOf(charactersIn: "!nace"),
-                   let count = Int(String(item.prefix(upTo:countIndex))),
+                   let count = Int(String(item.prefix(upTo: countIndex))),
                    let controlIndex = item.firstIndexOf(charactersIn: "nace"),
                    let controlChar = ControlChar(rawValue: String(item.suffix(from: controlIndex))) {
                     return (count, controlChar)
@@ -138,7 +139,7 @@ public enum IBAN {
     }
 
     public static let formatCharacters: [Character] = ["p", "b", "d", "k", "K", "r", "s", "X"]
-    public static var formatKeys: String = { formatCharacters.reduce("", { "\($0)\($1)" } ) }()  // "pbdkKrsX"
+    public static var formatKeys: String = { formatCharacters.reduce("", { "\($0)\($1)" }) }()  // "pbdkKrsX"
 
     public static var formatCharacterSet: CharacterSet {
         return CharacterSet(charactersIn: formatKeys)
@@ -149,7 +150,7 @@ public enum IBAN {
             fatalError("invalid country: \(country)")
         }
         let offset = string.count - string.replacingOccurrences(of: " ", with: "").count
-        return String(string.prefix(length+offset-2))
+        return String(string.prefix(length + offset - 2))
     }
 
     public static func placeholder(_ country: String, with placeholderChar: Character = "•") -> String {

--- a/Sources/Core/Payment/IBAN.swift
+++ b/Sources/Core/Payment/IBAN.swift
@@ -6,88 +6,204 @@
 
 import Foundation
 
+extension String {
+    public func firstIndexOf(charactersIn string: String) -> Index? {
+        let index = self.firstIndex { (character) -> Bool in
+            if let unicodeScalar = character.unicodeScalars.first, character.unicodeScalars.count == 1 {
+                return CharacterSet(charactersIn: string).contains(unicodeScalar)
+            }
+            return false
+        }
+        return index
+    }
+}
+
 // sample IBANs from https://www.iban.com/structure
 // DE75512108001245126199
 // NL02ABNA0123456789
 
-// length and formatting info for SEPA IBANs
-// see https://en.wikipedia.org/wiki/International_Bank_Account_Number#IBAN_formats_by_country
+
+/**
+ Supported official IBAN (ISO 13616) formats see:
+ https://de.wikipedia.org/wiki/Internationale_Bankkontonummer#IBAN-Struktur_in_verschiedenen_Ländern
+ To give a user a hint while typing, the format string contains special characters:
+
+ p  Prüfsumme
+ b   Stelle der Bankleitzahl 
+ d   Kontotyp 
+ k   Stelle der Kontonummer 
+ K   Kontrollzeichen (Großbuchstabe oder Ziffer) 
+ r   Regionalcode 
+ s   Stelle der Filialnummer (Branch Code / code guichet) 
+ X   sonstige Funktionen
+ */
+
+/**
+ Length and formatting info for SEPA IBANs see:
+ https://en.wikipedia.org/wiki/International_Bank_Account_Number#IBAN_formats_by_country
+
+ ISO 13616 IBAN formats see (page 6):
+ https://www.swift.com/resource/iban-registry-pdf
+ 
+ The following character representations are used to choose the corresponding soft keyboard:
+ n - Digits (numeric characters 0 to 9 only)
+ a - Upper case letters (alphabetic characters A-Z only)
+ c - upper and lower case alphanumeric characters (A-Z, a-z and 0-9)
+ e - blank space
+
+ The following length indications are used:
+ nn! fixedlength
+ nn maximum length
+ */
 
 public enum IBAN {
-    private static let info: [String: (Int, String)] = [
-        "AD": (24, "•• •••• •••• •••• •••• ••••"),
-        "AT": (20, "•• •••• •••• •••• ••••"),
-        "BE": (16, "•• •••• •••• ••••"),
-        "BG": (22, "•• •••• •••• •••• •••• ••"),
-        "HR": (21, "•• •••• •••• •••• •••• •"),
-        "CY": (28, "•• •••• •••• •••• •••• •••• ••••"),
-        "CZ": (24, "•• •••• •••• •••• •••• ••••"),
-        "FO": (18, "•• •••• •••• •••• ••"),
-        "GL": (18, "•• •••• •••• •••• ••"),
-        "DK": (18, "•• •••• •••• •••• ••"),
-        "EE": (20, "•• •••• •••• •••• ••••"),
-        "FI": (18, "•• •••• •••• •••• ••"),
-        "FR": (27, "•• •••• •••• •••• •••• •••• •••"),
-        "DE": (22, "•• •••• •••• •••• •••• ••"),
-        "GI": (23, "•• •••• •••• •••• •••• •••"),
-        "GR": (27, "•• •••• •••• •••• •••• •••• •••"),
-        "HU": (28, "•• •••• •••• •••• •••• •••• ••••"),
-        "IS": (26, "•• •••• •••• •••• •••• •••• ••"),
-        "IE": (22, "•• •••• •••• •••• •••• ••"),
-        "IT": (27, "•• •••• •••• •••• •••• •••• •••"),
-        "LV": (21, "•• •••• •••• •••• •••• •"),
-        "LI": (21, "•• •••• •••• •••• •••• •"),
-        "LT": (20, "•• •••• •••• •••• ••••"),
-        "LU": (20, "•• •••• •••• •••• ••••"),
-        "MT": (31, "•• •••• •••• •••• •••• •••• •••• •••"),
-        "MC": (27, "•• •••• •••• •••• •••• •••• •••"),
-        "NL": (18, "•• •••• •••• •••• ••"),
-        "NO": (15, "•• •••• •••• •••"),
-        "PL": (28, "•• •••• •••• •••• •••• •••• ••••"),
-        "PT": (25, "•• •••• •••• •••• •••• •••• •"),
-        "RO": (24, "•• •••• •••• •••• •••• ••••"),
-        "SM": (27, "•• •••• •••• •••• •••• •••• •••"),
-        "SK": (24, "•• •••• •••• •••• •••• ••••"),
-        "SI": (19, "•• •••• •••• •••• •••"),
-        "ES": (24, "•• •••• •••• •••• •••• ••••"),
-        "SE": (24, "•• •••• •••• •••• •••• ••••"),
-        "CH": (21, "•• •••• •••• •••• •••• •"),
-        "GB": (22, "•• •••• •••• •••• •••• ••"),
-        "VA": (22, "•• •••• •••• •••• •••• ••")
+    private static let info: [String: (length: Int, mapping: [String], format: String)] = [
+        "AD": (24, ["4!n", "4!n", "12!c"], "pp bbbb ssss kkkk kkkk kkkk"),
+        "AT": (20, ["5!n", "11!n"], "pp bbbb bkkk kkkk kkkk"),
+        "BE": (16, ["3!n", "7!n", "2!n"], "pp bbbk kkkk kkKK"),
+        "BG": (22, ["4!a", "4!n", "2!n", "8!c"], "pp bbbb ssss ddkk kkkk kk"),
+        "CH": (21, ["5!n", "12!c"], "pp bbbb bkkk kkkk kkkk k"),
+        "CY": (28, ["3!n", "5!n", "16!c"], "pp bbbs ssss kkkk kkkk kkkk kkkk"),
+        "CZ": (24, ["4!n", "6!n", "10!n"], "pp bbbb kkkk kkkk kkkk kkkk"),
+        "DE": (22, ["8!n", "10!n"], "pp bbbb bbbb kkkk kkkk kk"),
+        "DK": (18, ["4!n", "9!n", "1!n"], "pp bbbb kkkk kkkk kK"),
+        "EE": (20, ["2!n", "2!n", "11!n", "1!n"], "pp bbkk kkkk kkkk kkkK"),
+        "ES": (24, ["4!n", "4!n", "1!n", "1!n", "10!n"], "pp bbbb ssss KKkk kkkk kkkk"),
+        "FI": (18, ["3!n", "11!n"], "pp bbbb bbkk kkkk kK"),
+        "FO": (18, ["4!n", "9!n", "1!n"], "pp bbbb kkkk kkkk kK"),
+        "FR": (27, ["5!n", "5!n", "11!c", "2!n"], "pp bbbb bsss sskk kkkk kkkk kKK"),
+        "GB": (22, ["4!a", "6!n", "8!n"], "pp bbbb ssss sskk kkkk kk"),
+        "GI": (23, ["4!a", "15!c"], "pp bbbb kkkk kkkk kkkk kkk"),
+        "GL": (18, ["4!n", "9!n", "1!n"], "pp bbbb kkkk kkkk kK"),
+        "GR": (27, ["3!n", "4!n", "16!c"], "pp bbbs sssk kkkk kkkk kkkk kkk"),
+        "HR": (21, ["7!n", "10!n"], "pp bbbb bbbk kkkk kkkk k"),
+        "HU": (28, ["3!n", "4!n", "1!n", "15!n", "1!n"], "pp bbbs sssK kkkk kkkk kkkk kkkK"),
+        "IE": (22, ["4!a", "6!n", "8!n"], "pp bbbb ssss sskk kkkk kk"),
+        "IS": (26, ["4!n", "2!n", "6!n", "10!n"], "pp bbbb sskk kkkk XXXX XXXX XX"),
+        "IT": (27, ["1!a", "5!n", "5!n", "12!c"], "pp Kbbb bbss sssk kkkk kkkk kkk"),
+        "LI": (21, ["5!n", "12!c"], "pp bbbb bkkk kkkk kkkk k"),
+        "LT": (20, ["5!n", "11!n"], "pp bbbb bkkk kkkk kkkk"),
+        "LU": (20, ["3!n", "13!c"], "pp bbbk kkkk kkkk kkkk"),
+        "LV": (21, ["4!a", "13!c"], "pp bbbb kkkk kkkk kkkk k"),
+        "MC": (27, ["5!n", "5!n", "11!c", "2!n"], "pp bbbb bsss sskk kkkk kkkk kKK"),
+        "MT": (31, ["4!a", "5!n", "18!c"], "pp bbbb ssss skkk kkkk kkkk kkkk kkk"),
+        "NL": (18, ["4!a", "10!n"], "pp bbbb kkkk kkkk kk"),
+        "NO": (15, ["4!n", "6!n", "1!n"], "pp bbbb kkkk kkK"),
+        "PL": (28, ["8!n", "16!n"], "pp bbbs sssK kkkk kkkk kkkk kkkk"),
+        "PT": (25, ["4!n", "4!n", "11!n", "2!n"], "pp bbbb ssss kkkk kkkk kkkK K"),
+        "RO": (24, ["4!a", "16!c"], "pp bbbb kkkk kkkk kkkk kkkk"),
+        "SE": (24, ["3!n", "16!n", "1!n"], "pp bbbk kkkk kkkk kkkk kkkK"),
+        "SI": (19, ["5!n", "8!n", "2!n"], "pp bbss skkk kkkk kKK"),
+        "SK": (24, ["4!n", "6!n", "10!n"], "pp bbbb ssss sskk kkkk kkkk"),
+        "SM": (27, ["1!a", "5!n", "5!n", "12!c"], "pp Kbbb bbss sssk kkkk kkkk kkk"),
+        "VA": (22, ["3!n", "15!n"], "pp bbbk kkkk kkkk kkkk kk")
     ]
+    
+    public enum ControlChar: String {
+        case digits = "n"
+        case uppercaseLetters = "a"
+        case alphanumerics = "c"
+        case space = "e"
+    }
+    
+    public static func keyboardMapping(_ country: String) -> String {
+        guard let mapping = self.info[country]?.mapping, let length = length(country) else {
+            fatalError("invalid country: \(country)")
+        }
+        var string = String("\(country)nn")
+        var counter = string.count
+        
+        for item in mapping {
+            func split() -> (count: Int, control: ControlChar)? {
+                if let countIndex = item.firstIndexOf(charactersIn: "!nace"),
+                   let count = Int(String(item.prefix(upTo:countIndex))),
+                   let controlIndex = item.firstIndexOf(charactersIn: "nace"),
+                   let controlChar = ControlChar(rawValue: String(item.suffix(from: controlIndex))) {
+                    return (count, controlChar)
+                }
+                return nil
+            }
+            if let map = split() {
+                for _ in 0..<map.count {
+                    string.append(map.control.rawValue)
+                }
+                counter += map.count
+            }
+        }
+        if length != counter {
+            print("warning different length: \(length) from keymapping -> \(counter) (\(string)")
+        }
+        let pretty = IBAN.prettyPrint(string)
+        return String(pretty.suffix(pretty.count - 2))
+    }
+    
+    public static let formatCharacters: [Character] = ["p", "b", "d", "k", "K", "r", "s", "X"]
+    public static var formatKeys: String = { formatCharacters.reduce("", { "\($0)\($1)" } ) }()  // "pbdkKrsX"
+    
+    public static var formatCharacterSet: CharacterSet {
+        return CharacterSet(charactersIn: formatKeys)
+    }
+    
+    public static func formatString(_ country: String) -> String {
+        guard let string = self.info[country]?.format, let length = length(country) else {
+            fatalError("invalid country: \(country)")
+        }
+        let offset = string.count - string.replacingOccurrences(of: " ", with: "").count
+        return String(string.prefix(length+offset-2))
+    }
 
+    public static func placeholder(_ country: String, with placeholderChar: Character = "•") -> String {
+        var result = formatString(country)
+        for char in formatCharacters {
+            result = result.replacingOccurrences(of: String(char), with: String(placeholderChar))
+        }
+        return result
+    }
+    
     public static var countries: [String] {
         return info.keys.compactMap({ $0 })
     }
-
+    
     public static func length(_ country: String) -> Int? {
-        return info[country]?.0
+        return info[country]?.length
     }
-
-    public static func placeholder(_ country: String) -> String? {
-        return self.info[country]?.1
-    }
-
+    
     public static func displayName(_ iban: String) -> String {
         let country = String(iban.prefix(2))
         let prefix = String(iban.prefix(4))
         let suffix = String(iban.suffix(2))
 
-        guard let placeholder = IBAN.placeholder(country) else {
+        guard length(country) != nil else {
             let len = max(iban.count - 6, 0)
             let dots = String(repeating: "•", count: len)
             return prefix + " " + dots + " " + suffix
         }
-
+        let placeholder = IBAN.placeholder(country)
         let start = placeholder.index(placeholder.startIndex, offsetBy: 2)
         let end = placeholder.index(placeholder.endIndex, offsetBy: -2)
 
         return prefix + String(placeholder[start..<end]) + suffix
     }
     
+    public static func validCharacterSet(_ country: String) -> CharacterSet {
+        var charset = CharacterSet(charactersIn: "0123456789 ")
+        
+        let mapping = keyboardMapping(country)
+
+        if mapping.contains(where: { $0 == Character(ControlChar.uppercaseLetters.rawValue) }) {
+            charset.formUnion(.uppercaseLetters)
+        }
+        if mapping.contains(where: { $0 == Character(ControlChar.alphanumerics.rawValue) }) {
+            charset.formUnion(.alphanumerics)
+        }
+        
+        return charset
+    }
+
     // see https://en.wikipedia.org/wiki/International_Bank_Account_Number#Modulo_operation_on_IBAN
     public static func verify(iban: String) -> Bool {
-        var rawBytes = Array(iban.utf8)
+        
+        var rawBytes = Array(iban.replacingOccurrences(of: " ", with: "").utf8)
         while rawBytes.count < 4 {
             rawBytes.append(0)
         }
@@ -100,5 +216,56 @@ public enum IBAN {
         }
 
         return check == 1
+    }
+}
+
+extension IBAN {
+    public static func countryName(_ country: String) -> String? {
+        return Locale.current.localizedString(forRegionCode: country)
+    }
+}
+
+extension IBAN {
+    public static func prettyPrint(_ iban: String) -> String {
+        let iban = iban.replacingOccurrences(of: " ", with: "")
+        let country = String(iban.prefix(2))
+        let placeholder = IBAN.placeholder(country)
+        
+        guard placeholder.replacingOccurrences(of: " ", with: "").count == iban.count - 2 else {
+            return iban
+        }
+        
+        var offset: Int = 4
+        let prefix = String(iban.prefix(offset))
+        
+        let start = placeholder.index(placeholder.startIndex, offsetBy: 2)
+        var result = prefix
+        
+        for char in String(placeholder[start...]) {
+            if char == " " {
+                result.append(" ")
+            } else {
+                let currentIndex = iban.index(iban.startIndex, offsetBy: offset)
+                result.append(String(iban[currentIndex]))
+                offset += 1
+            }
+        }
+        
+        return result
+    }
+}
+
+public struct IBANDefinition {
+    public let country: String
+    public let formatString: String
+    public let placeholder: String
+    public let keyboardMapping: String
+    
+    public init(country: String) {
+        self.country = country
+        
+        self.formatString = IBAN.formatString(country)
+        self.placeholder = IBAN.placeholder(country)
+        self.keyboardMapping = IBAN.keyboardMapping(country)
     }
 }

--- a/Sources/Core/Payment/IBANFormatter.swift
+++ b/Sources/Core/Payment/IBANFormatter.swift
@@ -111,10 +111,10 @@ extension IBANFormatter {
         guard let offset = currentOffset, offset <= formatString.count else {
             return nil
         }
-        let saveOffset = min(offset, formatString.count-1)
+        let saveOffset = min(offset, formatString.count - 1)
         var index = formatString.index(formatString.startIndex, offsetBy: saveOffset)
         if formatString[index] == " " {
-            let nextOffset = offset < formatString.count-1 ? offset + 1 : formatString.count - 1
+            let nextOffset = offset < formatString.count - 1 ? offset + 1 : formatString.count - 1
             index = formatString.index(formatString.startIndex, offsetBy: nextOffset)
         }
         return index

--- a/Sources/Core/Payment/IBANFormatter.swift
+++ b/Sources/Core/Payment/IBANFormatter.swift
@@ -14,7 +14,7 @@ public protocol FormatterSelectionHint {
 
 public class IBANFormatter: Formatter, FormatterSelectionHint {
     public var ibanDefinition: IBANDefinition
-        
+
     public var placeholder: String {
         return ibanDefinition.placeholder
     }
@@ -28,7 +28,7 @@ public class IBANFormatter: Formatter, FormatterSelectionHint {
     }
 
     public var currentOffset: Int?
-    
+
     public var currentControlChar: IBAN.ControlChar {
         guard let index = self.currentIndex,
                 let controlChar = IBAN.ControlChar(rawValue: String(ibanDefinition.keyboardMapping[index])) else {
@@ -42,11 +42,13 @@ public class IBANFormatter: Formatter, FormatterSelectionHint {
             
         super.init()
     }
-    public func placeholder(with char: Character) -> String {
-        return IBAN.placeholder(ibanDefinition.country, with: char)
-    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    public func placeholder(with char: Character) -> String {
+        return IBAN.placeholder(ibanDefinition.country, with: char)
     }
 
     private func isValid(_ value: String) -> Bool {
@@ -129,16 +131,12 @@ extension IBANFormatter {
         case regionCode
         case branchCode
         case miscCode
-        
+
         public var message: String {
             return self.rawValue
         }
-        
-        public var localizedString: String {
-            return NSLocalizedString(message, comment: "")
-        }
     }
-    
+
     /*
      pp  zweistellige Prüfsumme
      b   Stelle der Bankleitzahl 
@@ -154,7 +152,7 @@ extension IBANFormatter {
             return nil
         }
         let char = formatString[index]
-        
+
         switch char {
         case "p":
             return .checksum

--- a/Sources/Core/Payment/IBANFormatter.swift
+++ b/Sources/Core/Payment/IBANFormatter.swift
@@ -1,0 +1,179 @@
+//
+//  IBANFormatter.swift
+//  IBAN Formatter
+//
+//  Created by Uwe Tilemann on 29.01.23.
+//
+
+import Foundation
+
+public protocol FormatterSelectionHint {
+    var currentOffset: Int? { get set }
+    var currentControlChar: IBAN.ControlChar { get }
+}
+
+public class IBANFormatter: Formatter, FormatterSelectionHint {
+    public var ibanDefinition: IBANDefinition
+        
+    public var placeholder: String {
+        return ibanDefinition.placeholder
+    }
+
+    public var formatString: String {
+        return ibanDefinition.formatString
+    }
+
+    private var characterSet: CharacterSet {
+        IBAN.validCharacterSet(ibanDefinition.country)
+    }
+
+    public var currentOffset: Int?
+    
+    public var currentControlChar: IBAN.ControlChar {
+        guard let index = self.currentIndex,
+                let controlChar = IBAN.ControlChar(rawValue: String(ibanDefinition.keyboardMapping[index])) else {
+            return .digits
+        }
+        return controlChar
+    }
+
+    public init(country: String = "DE") {
+        self.ibanDefinition = IBANDefinition(country: country)
+            
+        super.init()
+    }
+    public func placeholder(with char: Character) -> String {
+        return IBAN.placeholder(ibanDefinition.country, with: char)
+    }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func isValid(_ value: String) -> Bool {
+        guard let invalidRange = value.rangeOfCharacter(from: characterSet.inverted) else {
+            return true
+        }
+        return invalidRange.isEmpty
+    }
+
+    private func convert(string: String) -> String {
+        let iban = string.replacingOccurrences(of: " ", with: "")
+        let inLength = iban.count
+        var offset: Int = 0
+        var result = ""
+
+        for char in String(formatString[formatString.startIndex...]) {
+            guard offset < inLength else {
+                continue
+            }
+            if char == " " {
+                result.append(" ")
+            } else {
+                let currentIndex = iban.index(iban.startIndex, offsetBy: offset)
+                result.append(String(iban[currentIndex]))
+                offset += 1
+            }
+        }
+        return result
+    }
+
+    public override func string(for obj: Any?) -> String? {
+        guard let string = obj as? String else {
+            return nil
+        }
+        return convert(string: string)
+    }
+
+    public override func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?,
+                                        for string: String,
+                                        errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
+        let hexValue = convert(string: string)
+
+        obj?.pointee = hexValue as AnyObject
+        return true
+    }
+
+    public override func isPartialStringValid(
+        _ partialString: String,
+        newEditingString newString: AutoreleasingUnsafeMutablePointer<NSString?>?,
+        errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?
+    ) -> Bool {
+        guard partialString.count <= placeholder.count else { return false }
+
+        return isValid(partialString)
+    }
+}
+
+extension IBANFormatter {
+    public var currentIndex: String.Index? {
+        guard let offset = currentOffset, offset <= formatString.count else {
+            return nil
+        }
+        let saveOffset = min(offset, formatString.count-1)
+        var index = formatString.index(formatString.startIndex, offsetBy: saveOffset)
+        if formatString[index] == " " {
+            let nextOffset = offset < formatString.count-1 ? offset + 1 : formatString.count - 1
+            index = formatString.index(formatString.startIndex, offsetBy: nextOffset)
+        }
+        return index
+    }
+}
+
+extension IBANFormatter {
+    public enum HintState: String {
+        case checksum
+        case bank
+        case account
+        case accountType
+        case controlCode
+        case regionCode
+        case branchCode
+        case miscCode
+        
+        public var message: String {
+            return self.rawValue
+        }
+        
+        public var localizedString: String {
+            return NSLocalizedString(message, comment: "")
+        }
+    }
+    
+    /*
+     pp  zweistellige Prüfsumme
+     b   Stelle der Bankleitzahl 
+     d   Kontotyp 
+     k   Stelle der Kontonummer 
+     K   Kontrollzeichen (Großbuchstabe oder Ziffer) 
+     r   Regionalcode 
+     s   Stelle der Filialnummer (Branch Code / code guichet) 
+     X   sonstige Funktionen
+     */
+    public var hintState: HintState? {
+        guard let index = currentIndex else {
+            return nil
+        }
+        let char = formatString[index]
+        
+        switch char {
+        case "p":
+            return .checksum
+        case "b":
+            return .bank
+        case "k":
+            return .account
+        case "d":
+            return .accountType
+        case "K":
+            return .controlCode
+        case "r":
+            return .regionCode
+        case "s":
+            return .branchCode
+        case "X":
+            return .miscCode
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/UI/Checkout/CheckoutStepsViewController.swift
+++ b/Sources/UI/Checkout/CheckoutStepsViewController.swift
@@ -253,7 +253,7 @@ extension CheckoutStepsViewController: SepaEditViewControllerDelegate {
 }
 
 extension CheckoutStepsViewController: SepaDataEditViewControllerDelegate {
-    func sepaDataEditViewControllerWillSave(_ viewController: SepaDataEditViewController, userInfo: [String : Any]?) {
+    func sepaDataEditViewControllerWillSave(_ viewController: SepaDataEditViewController, userInfo: [String: Any]?) {
         viewController.sepaDataEditViewControllerWillSave(viewController, userInfo: userInfo)
         viewModel.update()
     }

--- a/Sources/UI/PaymentMethods/SepaDataModel+AttributedString.swift
+++ b/Sources/UI/PaymentMethods/SepaDataModel+AttributedString.swift
@@ -1,0 +1,64 @@
+//
+//  SepaDataModel+AttributedString.swift
+//  IBAN Formatter
+//
+//  Created by Uwe Tilemann on 31.01.23.
+//
+
+import Foundation
+import UIKit
+
+extension SepaDataModel {
+    var emptyRange: NSRange? {
+        guard ibanNumber.count > 0 else {
+            return nil
+        }
+        return NSRange(location: ibanNumber.count, length: formatter.placeholder.count-ibanNumber.count)
+    }
+    var inputRange: NSRange? {
+        guard ibanNumber.count > 0 else {
+            return nil
+        }
+        return NSRange(location: 0, length: ibanNumber.count)
+    }
+}
+
+extension SepaDataModel {
+    var inputPlaceholderString: String {
+        return formatter.placeholder(with: "#")
+    }
+    
+    var lineBreakMode: NSLineBreakMode {
+        guard let offset = formatter.currentOffset  else {
+            return .byTruncatingTail
+        }
+        return offset < formatter.placeholder.count/2 ? .byTruncatingTail : .byTruncatingHead
+    }
+
+    func attributedInputPlaceholder(_ placeholderString: String) -> NSAttributedString {
+        let font: UIFont
+        if #available(iOS 15.0, *) {
+            font = .preferredFont(forTextStyle: .body)
+        } else {
+            font = .preferredFont(forTextStyle: placeholderString.count < 31 ? .body : .footnote)
+        }
+        let string = NSMutableAttributedString(
+            string: placeholderString,
+            attributes: [
+                NSAttributedString.Key.font: font,
+                NSAttributedString.Key.foregroundColor: UIColor.secondaryLabel
+            ])
+        
+        if let emptyRange = emptyRange {
+            string.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.secondaryLabel], range: emptyRange)
+        }
+        if let inputRange = inputRange {
+            string.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.label], range: inputRange)
+        }
+        return NSAttributedString(attributedString: string)
+    }
+    
+    var attributedInputPlaceholderString: NSAttributedString {
+        return attributedInputPlaceholder(inputPlaceholderString)
+    }
+}

--- a/Sources/UI/PaymentMethods/SepaDataModel+AttributedString.swift
+++ b/Sources/UI/PaymentMethods/SepaDataModel+AttributedString.swift
@@ -10,13 +10,13 @@ import UIKit
 
 extension SepaDataModel {
     var emptyRange: NSRange? {
-        guard ibanNumber.count > 0 else {
+        guard !ibanNumber.isEmpty else {
             return nil
         }
-        return NSRange(location: ibanNumber.count, length: formatter.placeholder.count-ibanNumber.count)
+        return NSRange(location: ibanNumber.count, length: formatter.placeholder.count - ibanNumber.count)
     }
     var inputRange: NSRange? {
-        guard ibanNumber.count > 0 else {
+        guard !ibanNumber.isEmpty else {
             return nil
         }
         return NSRange(location: 0, length: ibanNumber.count)
@@ -32,7 +32,7 @@ extension SepaDataModel {
         guard let offset = formatter.currentOffset  else {
             return .byTruncatingTail
         }
-        return offset < formatter.placeholder.count/2 ? .byTruncatingTail : .byTruncatingHead
+        return offset < formatter.placeholder.count / 2 ? .byTruncatingTail : .byTruncatingHead
     }
 
     func attributedInputPlaceholder(_ placeholderString: String) -> NSAttributedString {

--- a/Sources/UI/PaymentMethods/SepaDataModel+AttributedString.swift
+++ b/Sources/UI/PaymentMethods/SepaDataModel+AttributedString.swift
@@ -27,7 +27,7 @@ extension SepaDataModel {
     var inputPlaceholderString: String {
         return formatter.placeholder(with: "#")
     }
-    
+
     var lineBreakMode: NSLineBreakMode {
         guard let offset = formatter.currentOffset  else {
             return .byTruncatingTail
@@ -48,7 +48,6 @@ extension SepaDataModel {
                 NSAttributedString.Key.font: font,
                 NSAttributedString.Key.foregroundColor: UIColor.secondaryLabel
             ])
-        
         if let emptyRange = emptyRange {
             string.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.secondaryLabel], range: emptyRange)
         }
@@ -57,7 +56,7 @@ extension SepaDataModel {
         }
         return NSAttributedString(attributedString: string)
     }
-    
+
     var attributedInputPlaceholderString: NSAttributedString {
         return attributedInputPlaceholder(inputPlaceholderString)
     }

--- a/Sources/UI/PaymentMethods/SepaDataModel.swift
+++ b/Sources/UI/PaymentMethods/SepaDataModel.swift
@@ -22,27 +22,9 @@ public enum SepaStrings: String {
     
     case invalidIBAN
     case invalidIBANCountry
-    case invalidIBANNumber
-
-    case missingIBAN
-    case missingName
-    case missingCity
-    case missingCountry
     
     public var localizedString: String {
         return Asset.localizedString(forKey: "Snabble.Payment.SEPA.\(self.rawValue)")
-    }
-}
-
-extension String {
-    func firstIndexOf(charactersIn string: String) -> Index? {
-        let index = self.firstIndex { (character) -> Bool in
-            if let unicodeScalar = character.unicodeScalars.first, character.unicodeScalars.count == 1 {
-                return CharacterSet(charactersIn: string).contains(unicodeScalar)
-            }
-            return false
-        }
-        return index
     }
 }
 
@@ -108,11 +90,18 @@ extension Publisher where Failure == Never {
 
 public final class SepaDataModel: ObservableObject {
     
-    @Published public var ibanCountry: String
+    public var formatter: IBANFormatter
+  
+    @Published public var ibanCountry: String {
+        didSet {
+            if !ibanCountry.isEmpty {
+                self.formatter = IBANFormatter(country: ibanCountry)
+            }
+        }
+    }
     @Published public var ibanNumber: String
     @Published public var lastname: String
     @Published public var city: String
-    @Published public var countryCode: String
 
     public var mandateReference: String?
     public var mandateMarkup: String?
@@ -153,38 +142,17 @@ public final class SepaDataModel: ObservableObject {
 
     private var projectId: Identifier<Project>?
 
-    public var paymentDetailName: String? {
-        if let detail = paymentDetail, case .payoneSepa(let data) = detail.methodData {
-            return data.lastName
-        }
-        return nil
-    }
-
-    public var paymentDetailMandate: String? {
-        if let detail = paymentDetail, case .payoneSepa(let data) = detail.methodData {
-            return data.mandateReference
-        }
-        return nil
-    }
-
-    public var paymentDetailMarkup: String? {
-        if let detail = paymentDetail, case .payoneSepa(let data) = detail.methodData {
-            return data.mandateMarkup
-        }
-        return nil
-    }
-
-    private var countryIsValid: Bool {
+    public var countryIsValid: Bool {
         return IBAN.length(self.ibanCountry.uppercased()) != nil
     }
 
-    private var hasIbanLength: Bool {
+    public var hasIbanLength: Bool {
         let length = (IBAN.length(self.ibanCountry.uppercased()) ?? 22)
         
         return self.sanitzedIban.count == length
     }
 
-    private var ibanIsValid: Bool {
+    public var ibanIsValid: Bool {
         return hasIbanLength && IBAN.verify(iban: self.sanitzedIban)
     }
 
@@ -194,6 +162,10 @@ public final class SepaDataModel: ObservableObject {
         
         return country + trimmed
     }
+    
+    public var IBANLength: Int {
+        return IBAN.length(self.ibanCountry.uppercased()) ?? 0
+    }
 
     public enum Policy {
         case simple
@@ -201,19 +173,19 @@ public final class SepaDataModel: ObservableObject {
     }
     public private(set) var policy: Policy = .simple
 
+    // output
+    @Published public var hintMessage = ""
+    @Published public var errorMessage: String = ""
+    
     @Published public var isValid = false {
         didSet {
-            if errorMessage.isEmpty == false {
+            if isValid == true, errorMessage.isEmpty == false {
                 self.errorMessage = ""
             }
         }
     }
 
-    // output
-    @Published public var hintMessage = ""
-    @Published public var errorMessage: String = ""
-
-    public var debounce: RunLoop.SchedulerTimeType.Stride = 0.5
+    public var debounce: RunLoop.SchedulerTimeType.Stride = 0.25
     public var minimumInputCount: Int = 2
 
     private var cancellables = Set<AnyCancellable>()
@@ -231,7 +203,7 @@ public final class SepaDataModel: ObservableObject {
             .debounce(for: debounce, scheduler: RunLoop.main)
             .removeDuplicates()
             .map { code in
-                return IBAN.placeholder(code.uppercased()) != nil
+                return IBAN.length(code.uppercased()) != nil
             }
             .eraseToAnyPublisher()
     }()
@@ -271,8 +243,8 @@ public final class SepaDataModel: ObservableObject {
         }
 
         isIbanCountryValidPublisher
-            .combineLatest(isIbanNumberValidPublisher)
-            .map { validIbanCountry, validIbanNumber in
+            .combineLatest(isIbanNumberValidPublisher /*, isFocusedValidPublisher*/)
+            .map { validIbanCountry, validIbanNumber /*, validFocus*/ in
                 if !validIbanCountry && !validIbanNumber {
                     return SepaStrings.invalidIBAN.localizedString
                 } else if !validIbanCountry {
@@ -280,33 +252,52 @@ public final class SepaDataModel: ObservableObject {
                 } else if !validIbanNumber {
                     return SepaStrings.invalidIBAN.localizedString
                 }
-                
+                // no error message while entering iban and entered length < required length
+                if self.sanitzedIban.count < self.IBANLength {
+                    return ""
+                }
+                // check for valid iban
+                if !self.ibanIsValid {
+                    return SepaStrings.invalidIBAN.localizedString
+                }
+                return ""
+            }
+            .assign(to: \SepaDataModel.errorMessage, onWeak: self)
+            .store(in: &cancellables)
+
+        isIbanNumberValidPublisher
+            .map { validIbanNumber in
+                if let hintState = self.formatter.hintState {
+                    return hintState.localizedString
+                }
                 return ""
             }
             .assign(to: \SepaDataModel.hintMessage, onWeak: self)
             .store(in: &cancellables)
 
+        
         isFormValidPublisher
             .assign(to: \.isValid, onWeak: self)
             .store(in: &cancellables)
     }
 
-    public init(paymentDetail: PaymentMethodDetail? = nil, iban: String, lastname: String, city: String? = nil, countryCode: String? = "DE", projectId: Identifier<Project>? = nil) {
+    public init(paymentDetail: PaymentMethodDetail? = nil, iban: String, lastname: String, city: String? = nil, countryCode: String = "DE", projectId: Identifier<Project>? = nil) {
         self.paymentDetail = paymentDetail
         self.projectId = projectId
-        self.policy = (city != nil && countryCode != nil) ? .extended : .simple
+        self.policy = (city != nil) ? .extended : .simple
 
-        self.ibanCountry = iban.ibanCountry ?? countryCode ?? ""
+        let country = iban.ibanCountry ?? countryCode
+        self.formatter = IBANFormatter(country: country)
+        self.ibanCountry = country
         self.ibanNumber = iban.ibanNumber ?? ""
         self.lastname = lastname
         self.city = city ?? ""
-        self.countryCode = countryCode ?? ""
 
         setupPublishers()
     }
-
-    public convenience init(iban: String? = nil, projectId: Identifier<Project>) {
-        self.init(iban: iban ?? "", lastname: "", city: "", projectId: projectId)
+    
+    public convenience init(iban: String? = nil, countryCode: String = "DE", projectId: Identifier<Project>) {
+        self.init(iban: iban ?? "", lastname: "", city: "", countryCode: countryCode, projectId: projectId)
     }
 
     public convenience init(detail: PaymentMethodDetail, projectId: Identifier<Project>?) {
@@ -315,6 +306,27 @@ public final class SepaDataModel: ObservableObject {
 }
 
 extension SepaDataModel {
+    public var paymentDetailName: String? {
+        if let detail = paymentDetail, case .payoneSepa(let data) = detail.methodData {
+            return data.lastName
+        }
+        return nil
+    }
+
+    public var paymentDetailMandate: String? {
+        if let detail = paymentDetail, case .payoneSepa(let data) = detail.methodData {
+            return data.mandateReference
+        }
+        return nil
+    }
+
+    public var paymentDetailMarkup: String? {
+        if let detail = paymentDetail, case .payoneSepa(let data) = detail.methodData {
+            return data.mandateMarkup
+        }
+        return nil
+    }
+
     public var imageName: String? {
         return paymentDetail?.imageName
     }
@@ -338,7 +350,7 @@ extension SepaDataModel {
     public func save() async throws {
         if self.isValid,
            let cert = Snabble.shared.certificates.first,
-           let sepaData = PayoneSepaData(cert.data, iban: self.iban, lastName: self.lastname, city: self.city, countryCode: self.countryCode, projectId: self.projectId ?? SnabbleCI.project.id, mandateReference: self.mandateReference, mandateMarkup: self.mandateMarkup) {
+           let sepaData = PayoneSepaData(cert.data, iban: self.iban, lastName: self.lastname, city: self.city, countryCode: self.ibanCountry, projectId: self.projectId ?? SnabbleCI.project.id, mandateReference: self.mandateReference, mandateMarkup: self.mandateMarkup) {
             
             let detail = PaymentMethodDetail(sepaData)
             PaymentMethodDetails.save(detail)

--- a/Sources/UI/PaymentMethods/SepaDataModel.swift
+++ b/Sources/UI/PaymentMethods/SepaDataModel.swift
@@ -22,6 +22,7 @@ public enum SepaStrings: String {
     
     case invalidIBAN
     case invalidIBANCountry
+    case validIBAN
     
     public var localizedString: String {
         return Asset.localizedString(forKey: "Snabble.Payment.SEPA.\(self.rawValue)")

--- a/Sources/UI/PaymentMethods/SepaDataModel.swift
+++ b/Sources/UI/PaymentMethods/SepaDataModel.swift
@@ -267,7 +267,7 @@ public final class SepaDataModel: ObservableObject {
             .store(in: &cancellables)
 
         isIbanNumberValidPublisher
-            .map { validIbanNumber in
+            .map { _ in
                 if let hintState = self.formatter.hintState {
                     return hintState.localizedString
                 }

--- a/Sources/UI/PaymentMethods/SepaDataModel.swift
+++ b/Sources/UI/PaymentMethods/SepaDataModel.swift
@@ -89,9 +89,9 @@ extension Publisher where Failure == Never {
 }
 
 public final class SepaDataModel: ObservableObject {
-    
+
     public var formatter: IBANFormatter
-  
+
     @Published public var ibanCountry: String {
         didSet {
             if !ibanCountry.isEmpty {
@@ -148,7 +148,7 @@ public final class SepaDataModel: ObservableObject {
 
     public var hasIbanLength: Bool {
         let length = (IBAN.length(self.ibanCountry.uppercased()) ?? 22)
-        
+
         return self.sanitzedIban.count == length
     }
 
@@ -159,10 +159,10 @@ public final class SepaDataModel: ObservableObject {
     private var sanitzedIban: String {
         let country = self.ibanCountry.uppercased()
         let trimmed = self.ibanNumber.replacingOccurrences(of: " ", with: "")
-        
+
         return country + trimmed
     }
-    
+
     public var IBANLength: Int {
         return IBAN.length(self.ibanCountry.uppercased()) ?? 0
     }
@@ -176,7 +176,7 @@ public final class SepaDataModel: ObservableObject {
     // output
     @Published public var hintMessage = ""
     @Published public var errorMessage: String = ""
-    
+
     @Published public var isValid = false {
         didSet {
             if isValid == true, errorMessage.isEmpty == false {
@@ -243,8 +243,8 @@ public final class SepaDataModel: ObservableObject {
         }
 
         isIbanCountryValidPublisher
-            .combineLatest(isIbanNumberValidPublisher /*, isFocusedValidPublisher*/)
-            .map { validIbanCountry, validIbanNumber /*, validFocus*/ in
+            .combineLatest(isIbanNumberValidPublisher)
+            .map { validIbanCountry, validIbanNumber in
                 if !validIbanCountry && !validIbanNumber {
                     return SepaStrings.invalidIBAN.localizedString
                 } else if !validIbanCountry {
@@ -275,7 +275,6 @@ public final class SepaDataModel: ObservableObject {
             .assign(to: \SepaDataModel.hintMessage, onWeak: self)
             .store(in: &cancellables)
 
-        
         isFormValidPublisher
             .assign(to: \.isValid, onWeak: self)
             .store(in: &cancellables)
@@ -295,7 +294,7 @@ public final class SepaDataModel: ObservableObject {
 
         setupPublishers()
     }
-    
+
     public convenience init(iban: String? = nil, countryCode: String = "DE", projectId: Identifier<Project>) {
         self.init(iban: iban ?? "", lastname: "", city: "", countryCode: countryCode, projectId: projectId)
     }
@@ -351,10 +350,10 @@ extension SepaDataModel {
         if self.isValid,
            let cert = Snabble.shared.certificates.first,
            let sepaData = PayoneSepaData(cert.data, iban: self.iban, lastName: self.lastname, city: self.city, countryCode: self.ibanCountry, projectId: self.projectId ?? SnabbleCI.project.id, mandateReference: self.mandateReference, mandateMarkup: self.mandateMarkup) {
-            
+
             let detail = PaymentMethodDetail(sepaData)
             PaymentMethodDetails.save(detail)
-            
+
             paymentDetail = detail
 
             DispatchQueue.main.async {

--- a/Sources/UI/PaymentMethods/SepaDataView.swift
+++ b/Sources/UI/PaymentMethods/SepaDataView.swift
@@ -18,15 +18,13 @@ extension View {
 #endif
 
 struct UIKitLabel: UIViewRepresentable {
-    
-    fileprivate var configuration = { (view: UILabel) in
-    }
+    fileprivate var configuration = { (view: UILabel) in }
 
     func makeUIView(context: UIViewRepresentableContext<Self>) -> UILabel {
         let label = UILabel()
         return label
     }
-    
+
     func updateUIView(_ uiView: UILabel, context: UIViewRepresentableContext<Self>) {
         configuration(uiView)
     }
@@ -75,6 +73,7 @@ struct IBANHintView: View {
     private var hintMessage: String {
         return model.hintMessage.isEmpty ? IBANFormatter.HintState.checksum.localizedString : model.hintMessage
     }
+
     private var topPadding: CGFloat {
         if #available(iOS 15.0, *) {
             return 0
@@ -82,6 +81,7 @@ struct IBANHintView: View {
             return -10
         }
     }
+
     private var bottomPadding: CGFloat {
         if #available(iOS 15.0, *) {
             return 0
@@ -123,6 +123,7 @@ struct IBANHintView: View {
                 .foregroundColor(.secondary)
         }
     }
+
     @ViewBuilder
     var content: some View {
         VStack(alignment: .leading, spacing:0) {
@@ -131,8 +132,8 @@ struct IBANHintView: View {
                 .font(.footnote)
                 .padding(.top, topPadding)
                 .padding(.bottom, bottomPadding)
-       }
-   }
+        }
+    }
 
     var body: some View {
         content
@@ -144,7 +145,7 @@ struct IBANHintView: View {
 
 struct IBANErrorView: View {
     @ObservedObject var model: SepaDataModel
-    
+
     @ViewBuilder
     var content: some View {
         if !model.errorMessage.isEmpty {
@@ -161,7 +162,7 @@ struct IBANErrorView: View {
 
 public struct CountryPicker: View {
     @Binding var selectedCountry: String
-    
+
     public var body: some View {
         Picker(SepaStrings.countryCode.localizedString, selection: $selectedCountry) {
             ForEach(getLocales(), id: \.id) { country in
@@ -174,7 +175,7 @@ public struct CountryPicker: View {
 
 public struct IbanCountryPicker: View {
     @ObservedObject var model: SepaDataModel
-    
+
     public var body: some View {
         if model.countries.count == 1, let country = model.countries.first {
             Text(country)
@@ -193,12 +194,12 @@ public struct IbanCountryPicker: View {
 public struct SepaDataEditorView: View {
     @ObservedObject var model: SepaDataModel
     @State private var country: String
-    
+
     public init(model: SepaDataModel) {
         self.model = model
         country = model.formatter.ibanDefinition.country
     }
-    
+
     @ViewBuilder
     var button: some View {
         Button(action: {
@@ -221,7 +222,7 @@ public struct SepaDataEditorView: View {
         IbanCountryPicker(model: model)
             .foregroundColor(Color.accent())
     }
-    
+
     @ViewBuilder
     var ibanNumberView: some View {
         UIKitTextField(SepaStrings.iban.localizedString, text: $model.ibanNumber, formatter: model.formatter) {
@@ -236,6 +237,7 @@ public struct SepaDataEditorView: View {
             CountryPicker(selectedCountry: $model.ibanCountry)
         }
     }
+
     @ViewBuilder
     var footerView: some View {
         if !model.errorMessage.isEmpty {
@@ -244,9 +246,9 @@ public struct SepaDataEditorView: View {
             Text(keyed: "Snabble.Payment.SEPA.hint")
                 .font(.footnote)
                 .foregroundColor(.secondaryLabel)
-
         }
     }
+
     public var body: some View {
         Form {
             Section(
@@ -278,11 +280,11 @@ public struct SepaDataEditorView: View {
 
 public struct SepaDataDisplayView: View {
     @ObservedObject var model: SepaDataModel
-    
+
     public init(model: SepaDataModel) {
         self.model = model
     }
-    
+
     @ViewBuilder
     var displayData: some View {
         Form {
@@ -317,11 +319,11 @@ public struct SepaDataDisplayView: View {
         }
         )
     }
-    
+
     public var body: some View {
         displayData
     }
-    
+
     private func askToRemove() {
         let alert = AlertView(title: Asset.localizedString(forKey: "Snabble.Payment.SEPA.title"), message: Asset.localizedString(forKey: "Snabble.Payment.Delete.message"))
 
@@ -335,17 +337,16 @@ public struct SepaDataDisplayView: View {
         }))
     
         alert.show()
-
     }
 }
 
 public struct SepaDataView: View {
     @ObservedObject var model: SepaDataModel
-    
+
     public init(model: SepaDataModel) {
         self.model = model
     }
-    
+
     public var body: some View {
         if model.isEditable {
             SepaDataEditorView(model: model)

--- a/Sources/UI/PaymentMethods/SepaDataView.swift
+++ b/Sources/UI/PaymentMethods/SepaDataView.swift
@@ -128,11 +128,15 @@ struct IBANHintView: View {
     var content: some View {
         VStack(alignment: .leading, spacing: 0) {
             placeholder
-            message
-                .font(.footnote)
-                .padding(.top, topPadding)
-                .padding(.bottom, bottomPadding)
-        }
+            HStack {
+                message
+                    .font(.footnote)
+                    .padding(.top, topPadding)
+                    .padding(.bottom, bottomPadding)
+                Spacer()
+            }
+            .frame(minWidth: 280)
+       }
     }
 
     var body: some View {

--- a/Sources/UI/PaymentMethods/SepaDataView.swift
+++ b/Sources/UI/PaymentMethods/SepaDataView.swift
@@ -112,10 +112,10 @@ struct IBANHintView: View {
     var message: some View {
         if model.ibanNumber.count == model.formatter.placeholder.count {
             if model.ibanIsValid {
-                Label("validIBAN", systemImage: "checkmark.circle.fill")
+                Label(SepaStrings.validIBAN.localizedString, systemImage: "checkmark.circle.fill")
                     .foregroundColor(.green)
             } else {
-                Label("invalidIBAN", systemImage: "xmark.circle.fill")
+                Label(SepaStrings.invalidIBAN.localizedString, systemImage: "xmark.circle.fill")
                     .foregroundColor(.red)
             }
         } else {

--- a/Sources/UI/PaymentMethods/SepaDataView.swift
+++ b/Sources/UI/PaymentMethods/SepaDataView.swift
@@ -18,7 +18,7 @@ extension View {
 #endif
 
 struct UIKitLabel: UIViewRepresentable {
-    fileprivate var configuration = { (view: UILabel) in }
+    fileprivate var configuration = { (_: UILabel) in }
 
     func makeUIView(context: UIViewRepresentableContext<Self>) -> UILabel {
         let label = UILabel()
@@ -98,7 +98,7 @@ struct IBANHintView: View {
                 .padding(.top, 4)
         } else {
             GeometryReader { geom in
-                UIKitLabel() {
+                UIKitLabel {
                     $0.attributedText = attributedString
                     $0.lineBreakMode = model.lineBreakMode
                     $0.numberOfLines = 1
@@ -126,7 +126,7 @@ struct IBANHintView: View {
 
     @ViewBuilder
     var content: some View {
-        VStack(alignment: .leading, spacing:0) {
+        VStack(alignment: .leading, spacing: 0) {
             placeholder
             message
                 .font(.footnote)

--- a/Sources/UI/PaymentMethods/SepaEditViewController.swift
+++ b/Sources/UI/PaymentMethods/SepaEditViewController.swift
@@ -422,7 +422,7 @@ extension SepaEditViewController: UITextFieldDelegate {
     }
 
     private func placeholderFor(_ country: String) -> String {
-        return IBAN.placeholder(country) ?? "IBAN"
+        return IBAN.placeholder(country)
     }
 
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Sources/UI/PaymentMethods/SepaEditViewController.swift
+++ b/Sources/UI/PaymentMethods/SepaEditViewController.swift
@@ -480,11 +480,9 @@ extension SepaEditViewController: UITextFieldDelegate {
             let index = iban.index(iban.startIndex, offsetBy: country.count)
             iban = String(iban[index...])
         }
-        if let placeholder = IBAN.placeholder(country) {
-            return self.formatIban(placeholder, iban)
-        } else {
-            return iban
-        }
+        let placeholder = IBAN.placeholder(country)
+        
+        return self.formatIban(placeholder, iban)
     }
 
     private func formatIban(_ pattern: String, _ text: String) -> String {

--- a/Sources/UI/Resources/de.lproj/Localizable.strings
+++ b/Sources/UI/Resources/de.lproj/Localizable.strings
@@ -232,6 +232,22 @@
 
 "Snabble.Payment.SEPA.hint" = "Hinweis: Um dich und unsere Händler vor Missbrauch zu schützen, wird sich der Händler bei deiner ersten Zahlung per SEPA-Lastschrift deine Bankkarte zeigen lassen.";
 
+"Snabble.Payment.SEPA.Hint.account" = "Kontonummer";
+
+"Snabble.Payment.SEPA.Hint.accountType" = "Kontotyp";
+
+"Snabble.Payment.SEPA.Hint.bank" = "Bankleitzahl";
+
+"Snabble.Payment.SEPA.Hint.branchCode" = "Filialnummer";
+
+"Snabble.Payment.SEPA.Hint.checksum" = "Prüfsumme";
+
+"Snabble.Payment.SEPA.Hint.controlCode" = "Kontrollzeichen";
+
+"Snabble.Payment.SEPA.Hint.miscCode" = "sonstige Funktion";
+
+"Snabble.Payment.SEPA.Hint.regionCode" = "Regionalcode";
+
 "Snabble.Payment.SEPA.iban" = "IBAN";
 
 "Snabble.Payment.SEPA.invalidIBAN" = "Die eingegebene IBAN ist ungültig.";
@@ -255,6 +271,8 @@
 "Snabble.Payment.SEPA.payer" = "Zahlungspflichtiger";
 
 "Snabble.Payment.SEPA.title" = "SEPA-Lastschrift";
+
+"Snabble.Payment.SEPA.validIBAN" = "Gültige IBAN";
 
 "Snabble.Payment.success" = "Vielen Dank für deinen Einkauf";
 
@@ -648,6 +666,8 @@
 "Snabble.Shoppingcart.removeItem" = "%@ wirklich entfernen?";
 
 "Snabble.Shoppingcart.removeItems" = "Wirklich alle Produkte aus dem Warenkorb entfernen?";
+
+"Snabble.Shoppingcart.saved" = "gespart";
 
 "Snabble.ShoppingCart.title" = "Warenkorb";
 

--- a/Sources/UI/Resources/en.lproj/Localizable.strings
+++ b/Sources/UI/Resources/en.lproj/Localizable.strings
@@ -232,6 +232,22 @@
 
 "Snabble.Payment.SEPA.hint" = "Note: In order to protect you and our merchants against misuse, the merchant will have your bank card shown on your first payment by SEPA direct debit.";
 
+"Snabble.Payment.SEPA.Hint.account" = "Account number";
+
+"Snabble.Payment.SEPA.Hint.accountType" = "Account type";
+
+"Snabble.Payment.SEPA.Hint.bank" = "Bank number";
+
+"Snabble.Payment.SEPA.Hint.branchCode" = "Branch code";
+
+"Snabble.Payment.SEPA.Hint.checksum" = "Checksum";
+
+"Snabble.Payment.SEPA.Hint.controlCode" = "Control code";
+
+"Snabble.Payment.SEPA.Hint.miscCode" = "Other function";
+
+"Snabble.Payment.SEPA.Hint.regionCode" = "Region code";
+
 "Snabble.Payment.SEPA.iban" = "IBAN";
 
 "Snabble.Payment.SEPA.invalidIBAN" = "Please enter a valid IBAN.";
@@ -255,6 +271,8 @@
 "Snabble.Payment.SEPA.payer" = "Payer";
 
 "Snabble.Payment.SEPA.title" = "SEPA direct debit";
+
+"Snabble.Payment.SEPA.validIBAN" = "Valid IBAN";
 
 "Snabble.Payment.success" = "Thank you for shopping";
 
@@ -648,6 +666,8 @@
 "Snabble.Shoppingcart.removeItem" = "Really remove %@?";
 
 "Snabble.Shoppingcart.removeItems" = "Really remove all products from your shopping cart?";
+
+"Snabble.Shoppingcart.saved" = "saved";
 
 "Snabble.ShoppingCart.title" = "Shopping Cart";
 

--- a/Sources/UI/Resources/fr-CH.lproj/Localizable.strings
+++ b/Sources/UI/Resources/fr-CH.lproj/Localizable.strings
@@ -232,6 +232,22 @@
 
 "Snabble.Payment.SEPA.hint" = "Remarque : pour te protéger et protéger nos commerçants contre les abus, le commerçant te demandera de montrer ta carte bancaire lors de ton premier paiement par débit SEPA.";
 
+"Snabble.Payment.SEPA.Hint.account" = "Account number";
+
+"Snabble.Payment.SEPA.Hint.accountType" = "Account type";
+
+"Snabble.Payment.SEPA.Hint.bank" = "Bank number";
+
+"Snabble.Payment.SEPA.Hint.branchCode" = "Branch code";
+
+"Snabble.Payment.SEPA.Hint.checksum" = "Checksum";
+
+"Snabble.Payment.SEPA.Hint.controlCode" = "Control code";
+
+"Snabble.Payment.SEPA.Hint.miscCode" = "Other function";
+
+"Snabble.Payment.SEPA.Hint.regionCode" = "Region code";
+
 "Snabble.Payment.SEPA.iban" = "IBAN";
 
 "Snabble.Payment.SEPA.invalidIBAN" = "L’IBAN saisi n’est pas valide.";
@@ -255,6 +271,8 @@
 "Snabble.Payment.SEPA.payer" = "Payer";
 
 "Snabble.Payment.SEPA.title" = "Débit SEPA";
+
+"Snabble.Payment.SEPA.validIBAN" = "Valid IBAN";
 
 "Snabble.Payment.success" = "Merci pour ton achat !";
 
@@ -648,6 +666,8 @@
 "Snabble.Shoppingcart.removeItem" = "Es-tu sûr(e) de vouloir supprimer %@ ?";
 
 "Snabble.Shoppingcart.removeItems" = "Es-tu sûr(e) de vouloir supprimer tous les produits du panier ?";
+
+"Snabble.Shoppingcart.saved" = "saved";
 
 "Snabble.ShoppingCart.title" = "Panier";
 

--- a/Sources/UI/Resources/fr.lproj/Localizable.strings
+++ b/Sources/UI/Resources/fr.lproj/Localizable.strings
@@ -232,6 +232,22 @@
 
 "Snabble.Payment.SEPA.hint" = "Remarque : afin de vous protéger, ainsi que nos commerçants, contre les abus, le commerçant demandera à voir votre carte bancaire lors de votre premier paiement par prélèvement SEPA.";
 
+"Snabble.Payment.SEPA.Hint.account" = "Account number";
+
+"Snabble.Payment.SEPA.Hint.accountType" = "Account type";
+
+"Snabble.Payment.SEPA.Hint.bank" = "Bank number";
+
+"Snabble.Payment.SEPA.Hint.branchCode" = "Branch code";
+
+"Snabble.Payment.SEPA.Hint.checksum" = "Checksum";
+
+"Snabble.Payment.SEPA.Hint.controlCode" = "Control code";
+
+"Snabble.Payment.SEPA.Hint.miscCode" = "Other function";
+
+"Snabble.Payment.SEPA.Hint.regionCode" = "Region code";
+
 "Snabble.Payment.SEPA.iban" = "IBAN";
 
 "Snabble.Payment.SEPA.invalidIBAN" = "L'IBAN que vous avez saisi n'est pas valide.";
@@ -255,6 +271,8 @@
 "Snabble.Payment.SEPA.payer" = "Payer";
 
 "Snabble.Payment.SEPA.title" = "Prélèvement SEPA";
+
+"Snabble.Payment.SEPA.validIBAN" = "Valid IBAN";
 
 "Snabble.Payment.success" = "Merci beaucoup pour votre achat";
 
@@ -648,6 +666,8 @@
 "Snabble.Shoppingcart.removeItem" = "Supprimer vraiment %@ ?";
 
 "Snabble.Shoppingcart.removeItems" = "Supprimer vraiment tous les produits du panier ?";
+
+"Snabble.Shoppingcart.saved" = "saved";
 
 "Snabble.ShoppingCart.title" = "Panier d'achat";
 

--- a/Sources/UI/Resources/hu.lproj/Localizable.strings
+++ b/Sources/UI/Resources/hu.lproj/Localizable.strings
@@ -232,6 +232,22 @@
 
 "Snabble.Payment.SEPA.hint" = "Megjegyzés: A te és a kereskedőink visszaélésekkel szembeni védelme érdekében az első SEPA terhelési megbízásos fizetésednél a kereskedőnél megjelenik a bankkártyád.";
 
+"Snabble.Payment.SEPA.Hint.account" = "Account number";
+
+"Snabble.Payment.SEPA.Hint.accountType" = "Account type";
+
+"Snabble.Payment.SEPA.Hint.bank" = "Bank number";
+
+"Snabble.Payment.SEPA.Hint.branchCode" = "Branch code";
+
+"Snabble.Payment.SEPA.Hint.checksum" = "Checksum";
+
+"Snabble.Payment.SEPA.Hint.controlCode" = "Control code";
+
+"Snabble.Payment.SEPA.Hint.miscCode" = "Other function";
+
+"Snabble.Payment.SEPA.Hint.regionCode" = "Region code";
+
 "Snabble.Payment.SEPA.iban" = "IBAN";
 
 "Snabble.Payment.SEPA.invalidIBAN" = "A megadott IBAN érvénytelen.";
@@ -255,6 +271,8 @@
 "Snabble.Payment.SEPA.payer" = "Fizetésre kötelezett";
 
 "Snabble.Payment.SEPA.title" = "SEPA terhelési megbízás";
+
+"Snabble.Payment.SEPA.validIBAN" = "Valid IBAN";
 
 "Snabble.Payment.success" = "Köszönjük a vásárlásodat";
 
@@ -648,6 +666,8 @@
 "Snabble.Shoppingcart.removeItem" = "%@ tényleg eltávolítod?";
 
 "Snabble.Shoppingcart.removeItems" = "Az összes terméket eltávolítod a kosárból?";
+
+"Snabble.Shoppingcart.saved" = "megtakarítva";
 
 "Snabble.ShoppingCart.title" = "Kosár";
 

--- a/Sources/UI/Resources/it.lproj/Localizable.strings
+++ b/Sources/UI/Resources/it.lproj/Localizable.strings
@@ -232,6 +232,22 @@
 
 "Snabble.Payment.SEPA.hint" = "Nota: per proteggere te e i nostri commercianti da frodi, quando effettuerai il primo pagamento con addebito diretto SEPA, il commerciante chiederà di vedere la tua carta di credito.";
 
+"Snabble.Payment.SEPA.Hint.account" = "Account number";
+
+"Snabble.Payment.SEPA.Hint.accountType" = "Account type";
+
+"Snabble.Payment.SEPA.Hint.bank" = "Bank number";
+
+"Snabble.Payment.SEPA.Hint.branchCode" = "Branch code";
+
+"Snabble.Payment.SEPA.Hint.checksum" = "Checksum";
+
+"Snabble.Payment.SEPA.Hint.controlCode" = "Control code";
+
+"Snabble.Payment.SEPA.Hint.miscCode" = "Other function";
+
+"Snabble.Payment.SEPA.Hint.regionCode" = "Region code";
+
 "Snabble.Payment.SEPA.iban" = "IBAN";
 
 "Snabble.Payment.SEPA.invalidIBAN" = "L’IBAN inserito non è valido.";
@@ -255,6 +271,8 @@
 "Snabble.Payment.SEPA.payer" = "Payer";
 
 "Snabble.Payment.SEPA.title" = "Addebito diretto SEPA";
+
+"Snabble.Payment.SEPA.validIBAN" = "Valid IBAN";
 
 "Snabble.Payment.success" = "Grazie per il tuo acquisto";
 
@@ -648,6 +666,8 @@
 "Snabble.Shoppingcart.removeItem" = "Rimuovere davvero %@?";
 
 "Snabble.Shoppingcart.removeItems" = "Rimuovere davvero tutti i prodotti dal carrello?";
+
+"Snabble.Shoppingcart.saved" = "saved";
 
 "Snabble.ShoppingCart.title" = "Carrello";
 

--- a/Sources/UI/Resources/sk.lproj/Localizable.strings
+++ b/Sources/UI/Resources/sk.lproj/Localizable.strings
@@ -232,6 +232,22 @@
 
 "Snabble.Payment.SEPA.hint" = "Poznámka: Za účelom tvojej ochrany a ochrany našich obchodníkov pred zneužitím si obchodník pri tvojej prvej platbe prostredníctvom SEPA inkasa vyžiada tvoju bankovú kartu.";
 
+"Snabble.Payment.SEPA.Hint.account" = "Account number";
+
+"Snabble.Payment.SEPA.Hint.accountType" = "Account type";
+
+"Snabble.Payment.SEPA.Hint.bank" = "Bank number";
+
+"Snabble.Payment.SEPA.Hint.branchCode" = "Branch code";
+
+"Snabble.Payment.SEPA.Hint.checksum" = "Checksum";
+
+"Snabble.Payment.SEPA.Hint.controlCode" = "Control code";
+
+"Snabble.Payment.SEPA.Hint.miscCode" = "Other function";
+
+"Snabble.Payment.SEPA.Hint.regionCode" = "Region code";
+
 "Snabble.Payment.SEPA.iban" = "IBAN";
 
 "Snabble.Payment.SEPA.invalidIBAN" = "Zadaný IBAN je neplatný.";
@@ -255,6 +271,8 @@
 "Snabble.Payment.SEPA.payer" = "Platiteľ";
 
 "Snabble.Payment.SEPA.title" = "SEPA inkaso";
+
+"Snabble.Payment.SEPA.validIBAN" = "Valid IBAN";
 
 "Snabble.Payment.success" = "Ďakujeme za tvoj nákup";
 
@@ -648,6 +666,8 @@
 "Snabble.Shoppingcart.removeItem" = "Naozaj chceš odstrániť %@ z košíka?";
 
 "Snabble.Shoppingcart.removeItems" = "Naozaj chceš odstrániť všetky produkty z košíka?";
+
+"Snabble.Shoppingcart.saved" = "ušetrená suma";
 
 "Snabble.ShoppingCart.title" = "Košík";
 

--- a/Sources/UI/Utilities/SwiftUI/IBANFormatter+TextField.swift
+++ b/Sources/UI/Utilities/SwiftUI/IBANFormatter+TextField.swift
@@ -1,0 +1,51 @@
+/* 
+  IBANFormatter+TextField.strings
+  IBAN Formatter
+
+  Created by Uwe Tilemann on 29.01.23.
+  
+*/
+import Foundation
+import UIKit
+import SnabbleCore
+
+extension IBANFormatter: TextChangeFormatter {
+    func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        guard let text = textField.text else {
+            return true
+        }
+        if text.count == formatString.count, !IBAN.verify(iban: ibanDefinition.country + text) {
+            return false
+        }
+        return true
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> (updatedText: String?, updatedRange: UITextRange?, shouldChange: Bool) {
+        guard let text = textField.text,
+              let textRange = Range(range, in: text) else {
+            return (nil, nil, true)
+        }
+        let updatedText = text.replacingCharacters(in: textRange, with: string)
+
+        if let formattedText = self.string(for: updatedText) {
+            var textFieldRange: UITextRange?
+            let length = string.count
+            
+            if range.location < formattedText.count - 1, NSMaxRange(range) + length < formattedText.count {
+                let offset = (formattedText.count - updatedText.count)
+                let inserted = formattedText[formattedText.index(formattedText.startIndex, offsetBy: range.location)...formattedText.index(formattedText.startIndex, offsetBy: range.location+length-1)]
+                
+                let spaceInserted = inserted != string
+                
+                if let oldFieldRange = textField.selectedTextRange,
+                   let newStart = textField.position(from: oldFieldRange.start, offset: spaceInserted ? offset + length : length),
+                   let newEnd = textField.position(from: oldFieldRange.end, offset: spaceInserted ? offset + length : length),
+                   let newRange = textField.textRange(from: newStart, to: newEnd) {
+                    textFieldRange = newRange
+                }
+            }
+            return (formattedText, textFieldRange, false)
+        }
+        return (nil, nil, true)
+    }
+}

--- a/Sources/UI/Utilities/SwiftUI/IBANFormatter+UI.swift
+++ b/Sources/UI/Utilities/SwiftUI/IBANFormatter+UI.swift
@@ -26,6 +26,7 @@ extension IBANFormatter: TextChangeFormatter {
         return true
     }
 
+    // swiftlint:disable large_tuple
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> (updatedText: String?, updatedRange: UITextRange?, shouldChange: Bool) {
         guard let text = textField.text,
               let textRange = Range(range, in: text) else {
@@ -39,7 +40,7 @@ extension IBANFormatter: TextChangeFormatter {
 
             if range.location < formattedText.count - 1, NSMaxRange(range) + length < formattedText.count {
                 let offset = (formattedText.count - updatedText.count)
-                let inserted = formattedText[formattedText.index(formattedText.startIndex, offsetBy: range.location)...formattedText.index(formattedText.startIndex, offsetBy: range.location+length-1)]
+                let inserted = formattedText[formattedText.index(formattedText.startIndex, offsetBy: range.location)...formattedText.index(formattedText.startIndex, offsetBy: range.location + length - 1)]
 
                 let spaceInserted = inserted != string
 
@@ -54,4 +55,5 @@ extension IBANFormatter: TextChangeFormatter {
         }
         return (nil, nil, true)
     }
+    // swiftlint:enable large_tuple
 }

--- a/Sources/UI/Utilities/SwiftUI/IBANFormatter+UI.swift
+++ b/Sources/UI/Utilities/SwiftUI/IBANFormatter+UI.swift
@@ -9,6 +9,12 @@ import Foundation
 import UIKit
 import SnabbleCore
 
+extension IBANFormatter.HintState {
+    public var localizedString: String {
+        return Asset.localizedString(forKey: "Snabble.Payment.SEPA.Hint.\(message)")
+    }
+}
+
 extension IBANFormatter: TextChangeFormatter {
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         guard let text = textField.text else {
@@ -19,7 +25,7 @@ extension IBANFormatter: TextChangeFormatter {
         }
         return true
     }
-    
+
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> (updatedText: String?, updatedRange: UITextRange?, shouldChange: Bool) {
         guard let text = textField.text,
               let textRange = Range(range, in: text) else {
@@ -30,13 +36,13 @@ extension IBANFormatter: TextChangeFormatter {
         if let formattedText = self.string(for: updatedText) {
             var textFieldRange: UITextRange?
             let length = string.count
-            
+
             if range.location < formattedText.count - 1, NSMaxRange(range) + length < formattedText.count {
                 let offset = (formattedText.count - updatedText.count)
                 let inserted = formattedText[formattedText.index(formattedText.startIndex, offsetBy: range.location)...formattedText.index(formattedText.startIndex, offsetBy: range.location+length-1)]
-                
+
                 let spaceInserted = inserted != string
-                
+
                 if let oldFieldRange = textField.selectedTextRange,
                    let newStart = textField.position(from: oldFieldRange.start, offset: spaceInserted ? offset + length : length),
                    let newEnd = textField.position(from: oldFieldRange.end, offset: spaceInserted ? offset + length : length),

--- a/Sources/UI/Utilities/SwiftUI/UIKitTextField.swift
+++ b/Sources/UI/Utilities/SwiftUI/UIKitTextField.swift
@@ -1,0 +1,212 @@
+//
+//  UIKitTextField.swift
+//  IBAN Formatter
+//
+//  Created by Uwe Tilemann on 26.01.23.
+//
+
+import UIKit
+import SwiftUI
+import SnabbleCore
+
+extension UITextField {
+    var cursorOffset: Int? {
+        guard let range = selectedTextRange else { return nil }
+        return offset(from: beginningOfDocument, to: range.start)
+    }
+    var cursorIndex: String.Index? {
+        guard let location = cursorOffset, let text = text else { return nil }
+        return Range(.init(location: location, length: 0), in: text)?.lowerBound
+    }
+    var cursorDistance: Int? {
+        guard let cursorIndex = cursorIndex, let text = text else { return nil }
+        return text.distance(from: text.startIndex, to: cursorIndex)
+    }
+}
+
+protocol TextChangeFormatter {
+    func textFieldShouldEndEditing(_ textField: UITextField) -> Bool
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> (updatedText: String?, updatedRange: UITextRange?, shouldChange: Bool)
+}
+
+extension FormatterSelectionHint {
+    func updateKeyboard(for textField: UITextField) {
+        if let currentKeyboard: UIKeyboardType = self.currentControlChar == .digits ? .numberPad : .default,
+           currentKeyboard != textField.keyboardType {
+            textField.keyboardType = currentKeyboard
+            textField.autocapitalizationType = self.currentControlChar == .uppercaseLetters ? .allCharacters : .none
+            textField.resignFirstResponder()
+            textField.becomeFirstResponder()
+        }
+    }
+}
+
+struct UIKitTextField<Content: View>: UIViewRepresentable {
+
+    var label: String?
+    @Binding var text: String
+
+    var formatter: Formatter?
+    var isSecureTextEntry: Binding<Bool>?
+
+    var keyboardType: UIKeyboardType = .default
+    var returnKeyType: UIReturnKeyType = .default
+    var autocapitalizationType: UITextAutocapitalizationType = .words
+    var textContentType: UITextContentType?
+
+    var tag: Int?
+    var content: Content?
+    
+    init(_ label: String? = nil,
+         text: Binding<String>,
+         formatter: Formatter? = nil,
+         isSecureTextEntry: Binding<Bool>? = nil,
+         keyboardType: UIKeyboardType = .default,
+         returnKeyType: UIReturnKeyType = .default,
+         autocapitalizationType: UITextAutocapitalizationType = .words,
+         textContentType: UITextContentType? = nil,
+         tag: Int? = nil,
+        content: (() -> Content)? = nil) {
+        self.label = label
+        self._text = text
+        self.formatter = formatter
+        self.isSecureTextEntry = isSecureTextEntry
+        self.keyboardType = keyboardType
+        self.returnKeyType = returnKeyType
+        self.autocapitalizationType = autocapitalizationType
+        self.textContentType = textContentType
+        self.tag = tag
+        self.content = content?()
+    }
+
+    func makeUIView(context: UIViewRepresentableContext<UIKitTextField>) -> UITextField {
+        let textField = UITextField(frame: .zero)
+        textField.delegate = context.coordinator
+        
+        textField.placeholder = self.label
+        textField.returnKeyType = returnKeyType
+        textField.autocapitalizationType = autocapitalizationType
+        
+        if let formatter = self.formatter as? FormatterSelectionHint {
+            textField.keyboardType = formatter.currentControlChar == .digits ? .numberPad : .default
+        } else {
+            textField.keyboardType = self.keyboardType
+        }
+        textField.isSecureTextEntry = isSecureTextEntry?.wrappedValue ?? false
+        textField.textContentType = textContentType
+        if let tag = tag {
+            textField.tag = tag
+        }
+        if let content = self.content {
+            let contentView: UIView = UIHostingController(rootView: content).view
+            contentView.frame = CGRect(x: 0, y: 0, width: 280, height: 44)
+            contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            contentView.isOpaque = false
+            contentView.backgroundColor = .clear
+            
+            contentView.sizeToFit()
+
+            let keyboardToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+            
+            let leftButton = UIBarButtonItem(customView: contentView)
+            let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: textField, action: #selector(UITextField.endEditing(_:)))
+            keyboardToolbar.items = [leftButton, flexSpace, doneButton]
+            keyboardToolbar.sizeToFit()
+            
+            textField.inputAccessoryView = keyboardToolbar
+
+        }
+        textField.addTarget(context.coordinator, action: #selector(Coordinator.textFieldDidChange(_:)), for: .editingChanged)
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        return textField
+    }
+
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        uiView.text = text
+        uiView.isSecureTextEntry = isSecureTextEntry?.wrappedValue ?? false
+    }
+        
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    final class Coordinator: NSObject, UITextFieldDelegate {
+
+        let control: UIKitTextField
+
+        init(_ control: UIKitTextField) {
+            self.control = control
+        }
+
+        func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+            if let formatter = control.formatter as? TextChangeFormatter {
+                return formatter.textFieldShouldEndEditing(textField)
+            }
+            return true
+        }
+
+        @objc func textFieldDidChange(_ textField: UITextField) {
+            control.text = textField.text ?? ""
+        }
+
+        @objc func textFieldDidChangeSelection(_ textField: UITextField) {
+            guard var formatter = control.formatter as? FormatterSelectionHint else {
+                return
+            }
+            formatter.currentOffset = textField.cursorOffset
+            formatter.updateKeyboard(for: textField)
+        }
+
+        func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {            
+            if let char = string.cString(using: String.Encoding.utf8) {
+                let isBackSpace = strcmp(char, "\\b")
+                if string.isEmpty, isBackSpace == -92 {
+                    return true
+                } else if strcmp(char, "\\n") == -82 {
+                    return true
+                }
+            }
+            guard let formatter = control.formatter as? TextChangeFormatter else {
+                return true
+            }
+            
+            let result = formatter.textField(textField, shouldChangeCharactersIn: range, replacementString: string)
+            if result.shouldChange == false, let updatedText = result.updatedText {
+                textField.text = updatedText
+                self.textFieldDidChange(textField)
+            }
+            if let updatedRange = result.updatedRange {
+                DispatchQueue.main.async {
+                    textField.selectedTextRange = updatedRange
+                }
+            }
+            return result.shouldChange
+        }
+    }
+}
+
+extension UIKitTextField where Content == EmptyView {
+    init(_ label: String? = nil,
+         text: Binding<String>,
+         formatter: Formatter? = nil,
+         isSecureTextEntry: Binding<Bool>? = nil,
+         keyboardType: UIKeyboardType = .default,
+         returnKeyType: UIReturnKeyType = .default,
+         autocapitalizationType: UITextAutocapitalizationType = .words,
+         textContentType: UITextContentType? = nil,
+         tag: Int? = nil) {
+        self.label = label
+        self._text = text
+        self.formatter = formatter
+        self.isSecureTextEntry = isSecureTextEntry
+        self.keyboardType = keyboardType
+        self.returnKeyType = returnKeyType
+        self.autocapitalizationType = autocapitalizationType
+        self.textContentType = textContentType
+        self.tag = tag
+
+        self.content = nil
+    }
+}

--- a/Sources/UI/Utilities/SwiftUI/UIKitTextField.swift
+++ b/Sources/UI/Utilities/SwiftUI/UIKitTextField.swift
@@ -56,7 +56,7 @@ struct UIKitTextField<Content: View>: UIViewRepresentable {
 
     var tag: Int?
     var content: Content?
-    
+
     init(_ label: String? = nil,
          text: Binding<String>,
          formatter: Formatter? = nil,
@@ -82,11 +82,11 @@ struct UIKitTextField<Content: View>: UIViewRepresentable {
     func makeUIView(context: UIViewRepresentableContext<UIKitTextField>) -> UITextField {
         let textField = UITextField(frame: .zero)
         textField.delegate = context.coordinator
-        
+
         textField.placeholder = self.label
         textField.returnKeyType = returnKeyType
         textField.autocapitalizationType = autocapitalizationType
-        
+
         if let formatter = self.formatter as? FormatterSelectionHint {
             textField.keyboardType = formatter.currentControlChar == .digits ? .numberPad : .default
         } else {
@@ -103,17 +103,15 @@ struct UIKitTextField<Content: View>: UIViewRepresentable {
             contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             contentView.isOpaque = false
             contentView.backgroundColor = .clear
-            
             contentView.sizeToFit()
 
             let keyboardToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
-            
             let leftButton = UIBarButtonItem(customView: contentView)
             let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
             let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: textField, action: #selector(UITextField.endEditing(_:)))
             keyboardToolbar.items = [leftButton, flexSpace, doneButton]
             keyboardToolbar.sizeToFit()
-            
+
             textField.inputAccessoryView = keyboardToolbar
 
         }
@@ -127,11 +125,11 @@ struct UIKitTextField<Content: View>: UIViewRepresentable {
         uiView.text = text
         uiView.isSecureTextEntry = isSecureTextEntry?.wrappedValue ?? false
     }
-        
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
+
     final class Coordinator: NSObject, UITextFieldDelegate {
 
         let control: UIKitTextField
@@ -171,7 +169,7 @@ struct UIKitTextField<Content: View>: UIViewRepresentable {
             guard let formatter = control.formatter as? TextChangeFormatter else {
                 return true
             }
-            
+
             let result = formatter.textField(textField, shouldChangeCharactersIn: range, replacementString: string)
             if result.shouldChange == false, let updatedText = result.updatedText {
                 textField.text = updatedText

--- a/Sources/UI/Utilities/SwiftUI/UIKitTextField.swift
+++ b/Sources/UI/Utilities/SwiftUI/UIKitTextField.swift
@@ -26,7 +26,9 @@ extension UITextField {
 
 protocol TextChangeFormatter {
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool
+    // swiftlint:disable large_tuple
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> (updatedText: String?, updatedRange: UITextRange?, shouldChange: Bool)
+    // swiftlint:enable large_tuple
 }
 
 extension FormatterSelectionHint {
@@ -66,7 +68,7 @@ struct UIKitTextField<Content: View>: UIViewRepresentable {
          autocapitalizationType: UITextAutocapitalizationType = .words,
          textContentType: UITextContentType? = nil,
          tag: Int? = nil,
-        content: (() -> Content)? = nil) {
+         content: (() -> Content)? = nil) {
         self.label = label
         self._text = text
         self.formatter = formatter


### PR DESCRIPTION
This is a quite big PR.

- The IBAN definition was rewritten to enable switching of the required soft keyboard while entering an IBAN.
- Unlike the previous version, calling the IBAN enum with an unsupported country code results in a fatal error.
- To support iOS 14 and formatting IBANs on the fly a SwiftUI wrapper for UITextField exists. 
- The SwiftUI IBANHintView is used as an accessory view for the UITextField to give the user hints which part of an IBAN currently entered.

https://snabble.atlassian.net/browse/APPS-593