### PR TITLE
Apps-834 - Duplicate Payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+* Duplicate Payments #APPS-834
+
 ## [0.35.0] - 2023-04-28
 
 ### Fixed

--- a/Sources/UI/Checkout/CheckoutStepsViewController.swift
+++ b/Sources/UI/Checkout/CheckoutStepsViewController.swift
@@ -142,6 +142,7 @@ struct CheckoutView: View {
                             .shadow(color: Color("Shadow"), radius: 8, x: 0, y: 4)
                     }
                 }
+                .padding(.bottom, 80)
 
                 VStack {
                     Spacer()
@@ -155,7 +156,6 @@ struct CheckoutView: View {
                     .buttonStyle(AccentButtonStyle())
                     .padding([.bottom, .horizontal], 16)
                 }
-
             }
         }
     }
@@ -228,7 +228,14 @@ final class CheckoutStepsViewController: UIHostingController<CheckoutView> {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
-    
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+#if !MOCK_CHECKOUT
+        viewModel.stopTimer()
+#endif
+    }
+
     @objc func stepAction(userInfo: [String: Any]?) {
         if let userInfo = userInfo {
             if let action = userInfo["action"] as? String, action == "done" {


### PR DESCRIPTION
stopTimer in viewDidDisappear and add bottom padding to CheckoutView's ScrollView.

The SwiftUI views should only be dismissed, if a request returns successfully. (e.g. .cancelPayment()) in SupervisorCheckViewController.swift:44). Please check all possible code fragments.