### PR TITLE
`ExternalBilling` wird als Kauf auf Rechnung interpretiert, aber sollte eine Kundenkarte sein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.38.1]
 
+### Added
+* Make icon of PaymentMethodDetail public #APPS-963
+
 ### Fixed
 * `ExternalBilling` wird als Kauf auf Rechnung interpretiert, aber sollte eine Kundenkarte sein #APPS-995
-## [unreleased]
-
-### Changed
-* Make icon of PaymentMethodDetail public #APPS-963
 
 ### Updated
 * apple/swift-log.git 1.5.3 (was 1.5.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.1]
+
+### Fixed
+* `ExternalBilling` wird als Kauf auf Rechnung interpretiert, aber sollte eine Kundenkarte sein #APPS-995
+
 ## [0.38.0] - 2023-07-11
 
 ### Added

--- a/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
       }
     },
     {

--- a/Sources/Core/API/Snabble.swift
+++ b/Sources/Core/API/Snabble.swift
@@ -45,6 +45,10 @@ public struct Config {
     /// load shop list from the `activeShops` endpoint?
     public var loadActiveShops = false
 
+    // Workaround: Bug Fix #APPS-995
+    // https://snabble.atlassian.net/browse/APPS-995
+    public var showExternalBilling = true
+
     // debug mode only:
     // SQL statements that are executed just before the product database is opened
     public var initialSQL: [String]?
@@ -140,7 +144,7 @@ public class Snabble {
     public lazy var shoppingCartManager = ShoppingCartManager()
 
     /// Will be set with setup(config:, completion:)
-    let config: Config
+    public let config: Config
 
     /// Will be created in setup(config:, completion:)
     public let tokenRegistry: TokenRegistry

--- a/Sources/Core/Payment/PaymentMethods.swift
+++ b/Sources/Core/Payment/PaymentMethods.swift
@@ -79,11 +79,14 @@ public enum RawPaymentMethod: String, Decodable {
         switch self {
         case .deDirectDebit, .paydirektOneKlick,
              .creditCardVisa, .creditCardMastercard, .creditCardAmericanExpress,
-             .twint, .postFinanceCard,
-             .externalBilling:
+             .twint, .postFinanceCard:
             return true
         case .qrCodePOS, .qrCodeOffline, .gatekeeperTerminal, .customerCardPOS, .applePay:
             return false
+        // Workaround: Bug Fix #APPS-995
+        // https://snabble.atlassian.net/browse/APPS-995
+        case .externalBilling:
+            return Snabble.shared.config.showExternalBilling
         }
 
     }

--- a/Sources/UI/ShoppingCart/ShoppingCart+PaymentSelection.swift
+++ b/Sources/UI/ShoppingCart/ShoppingCart+PaymentSelection.swift
@@ -357,6 +357,11 @@ final class PaymentMethodSelector {
                 }
                 return actions
             } else {
+                // Workaround: Bug Fix #APPS-995
+                // https://snabble.atlassian.net/browse/APPS-995
+                if method == .externalBilling && Snabble.shared.config.showExternalBilling == false {
+                    return []
+                }
                 let subtitle = Asset.localizedString(forKey: "Snabble.Shoppingcart.noPaymentData")
                 let title = Self.attributedString(
                     forText: method.displayName,


### PR DESCRIPTION
https://snabble.atlassian.net/browse/APPS-995

* make `config` public
* adds `showExternalBilling` as a workaround variable to fix the issue

### How to test
* add this branch in `teo-ios` external billing isn't shown as available method to be added, but the customer card is shown if added.

### Definition of Done
- [x] Anforderungen erfüllt
- [x] Deployment Target
- [x] Home-Button vs. Face-ID Device (SafeArea Guides)
- [x] Dark / Light Mode
- [x] Product Owner Review
