### PR TITLE
Scan&Go und Grab&Go Shops unterscheiden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-### Changed
+### Added
 * Make icon of PaymentMethodDetail public #APPS-963
+* Scan&Go und Grab&Go Shops unterscheiden #APPS-999
 
 ### Updated
 * apple/swift-log.git 1.5.3 (was 1.5.2)
 * groue/GRDB.swift 6.16.0 (was 6.15.0)
+* realm/SwiftLint 0.52.4 (was 0.52.3)
 
 ## [0.38.0] - 2023-07-11
 

--- a/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "f1e9245226002bb134884345d4809b9543da3666",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-06-17-a"
+        "revision" : "59ed009d2c4a5a6b78f75a25679b6417ac040dcf",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-04-a"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint",
       "state" : {
-        "revision" : "117405ce36cf364ece2c7aaf9ee7afed7efbabcc",
-        "version" : "0.52.3"
+        "revision" : "9eaecbedce469a51bd8487effbd4ab46ec8384ae",
+        "version" : "0.52.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "f1e9245226002bb134884345d4809b9543da3666",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-06-17-a"
+        "revision" : "59ed009d2c4a5a6b78f75a25679b6417ac040dcf",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-04-a"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint",
       "state" : {
-        "revision" : "117405ce36cf364ece2c7aaf9ee7afed7efbabcc",
-        "version" : "0.52.3"
+        "revision" : "9eaecbedce469a51bd8487effbd4ab46ec8384ae",
+        "version" : "0.52.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(url: "https://github.com/devicekit/DeviceKit.git", from: "5.0.0"),
         .package(url: "https://github.com/snabble/Pulley.git", from: "2.9.2"),
         .package(url: "https://github.com/chrs1885/WCAG-Colors.git", from: "1.0.0"),
-        .package(url: "https://github.com/realm/SwiftLint", exact: "0.52.3"),
+        .package(url: "https://github.com/realm/SwiftLint", exact: "0.52.4"),
     ],
     targets: [
         .target(

--- a/Sources/Core/Metadata/Shop+GrabAndGo.swift
+++ b/Sources/Core/Metadata/Shop+GrabAndGo.swift
@@ -1,0 +1,16 @@
+//
+//  Shop+GrabAndGo.swift
+//  
+//
+//  Created by Andreas Osberghaus on 2023-08-24.
+//
+
+/// extension for shop that adds Grab&Go-based stuff
+extension Shop {
+    public var isGrabAndGo: Bool {
+        guard let flag = external?["grabAndGoEnabled"] as? Bool else {
+            return false
+        }
+        return flag
+    }
+}


### PR DESCRIPTION
https://snabble.atlassian.net/browse/APPS-999

* adds `isGrabAndGo` method to `Shop`
* Update `SwiftLint` to `0.52.4`

### Definition of Done
- [x] Anforderungen erfüllt
- [x] Deployment Target
- [x] Home-Button vs. Face-ID Device (SafeArea Guides)
- [x] Dark / Light Mode
- [x] Product Owner Review
