### PR TITLE
update datatrans to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * add State to Autonomo session #APPS-1079
 
+### Updated
+* datatrans/ios-sdk 3.3.0 (was 2.7.2)
+
 ## [0.41.0] - 2023-10-23
 
 ### Added

--- a/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -6,7 +6,7 @@ name: DeviceKit, nameSpecified: DeviceKit, owner: devicekit, version: 5.1.0, sou
 
 name: GRDB.swift, nameSpecified: GRDB.swift, owner: groue, version: 6.20.2, source: https://github.com/groue/GRDB.swift
 
-name: ios-sdk, nameSpecified: Datatrans, owner: datatrans, version: 2.7.2, source: https://github.com/datatrans/ios-sdk
+name: ios-sdk, nameSpecified: Datatrans, owner: datatrans, version: 3.3.0, source: https://github.com/datatrans/ios-sdk
 
 name: KeychainAccess, nameSpecified: KeychainAccess, owner: kishikawakatsumi, version: 4.2.2, source: https://github.com/kishikawakatsumi/KeychainAccess
 

--- a/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/datatrans/ios-sdk.git",
       "state" : {
-        "revision" : "4783996f662b4e24b3f045b39b0f9c585c7edbdd",
-        "version" : "2.7.2"
+        "revision" : "09891385f6ad7f37a47048c7ad952d3199eed82b",
+        "version" : "3.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.20.2"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
-        .package(url: "https://github.com/datatrans/ios-sdk.git", from: "2.7.2"),
+        .package(url: "https://github.com/datatrans/ios-sdk.git", from: "3.3.0"),
         .package(url: "https://github.com/sberrevoets/SDCAlertView.git", from: "12.0.3"),
         .package(url: "https://github.com/devicekit/DeviceKit.git", from: "5.1.0"),
         .package(url: "https://github.com/snabble/Pulley.git", from: "2.9.2"),

--- a/Sources/Core/Metadata/EntryToken/Autonomo+EntryToken.swift
+++ b/Sources/Core/Metadata/EntryToken/Autonomo+EntryToken.swift
@@ -9,10 +9,10 @@ import Foundation
 
 public enum Autonomo {
     public enum State: String, Codable {
-        case entry_pending
-        case entry_denied
-        case client_entered
-        case cart_completed
+        case entryPending = "entry_pending"
+        case entryDenied = "entry_denied"
+        case clientEntered = "client_entered"
+        case cartCompleted = "cart_completed"
         case failed
     }
     public struct Session: Codable, Identifiable {


### PR DESCRIPTION
* update `datatrans/ios-sdk` to 3.3.0 (was 2.7.2)
   * https://github.com/datatrans/ios-sdk/releases/tag/3.3.0
   * No code changes needed
* Autonomo Session States wegen Code Convention angepasst.
   * _Identifier Name Violation: Enum element name 'entry_pending' should only contain alphanumeric and other allowed characters_

### Definition of Done
- [x] Anforderungen erfüllt
- [x] Deployment Target
- [x] Home-Button vs. Face-ID Device (SafeArea Guides)
- [x] Dark / Light Mode
- [x] Product Owner Review
