### PR TITLE
Hinweistexte im Supervisor Checkout nicht vorhanden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * add State to Autonomo session #APPS-1079
 
+### Fixed
+* Add Supervisor text info #APPS-1181
+
 ### Updated
 * datatrans/ios-sdk 3.3.0 (was 2.7.2)
 

--- a/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
+++ b/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
@@ -35,10 +35,15 @@ struct SupervisorView: View {
                 SwiftUI.Image(uiImage: uiImage)
                     .padding([.top, .bottom], 20)
             }
+            Text(Asset.localizedString(forKey: "Snabble.Payment.Online.message"))
+            Spacer()
             if let codeImage = model.codeImage {
                 SwiftUI.Image(uiImage: codeImage)
                     .padding([.top], 20)
             }
+            Text(model.idString)
+                .font(.footnote)
+                .padding(.top, 10)
             Spacer()
             Button(action: {
                 model.checkModel.cancelPayment()

--- a/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
+++ b/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
@@ -32,7 +32,7 @@ struct SupervisorView: View {
     var content: some View {
         VStack(spacing: 8) {
             Spacer()
-           if let uiImage = model.headerImage {
+            if let uiImage = model.headerImage {
                 SwiftUI.Image(uiImage: uiImage)
                     .padding([.top, .bottom], 20)
             }

--- a/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
+++ b/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
@@ -31,7 +31,8 @@ struct SupervisorView: View {
     @ViewBuilder
     var content: some View {
         VStack(spacing: 8) {
-            if let uiImage = model.headerImage {
+            Spacer()
+           if let uiImage = model.headerImage {
                 SwiftUI.Image(uiImage: uiImage)
                     .padding([.top, .bottom], 20)
             }
@@ -44,7 +45,8 @@ struct SupervisorView: View {
             Text(model.idString)
                 .font(.footnote)
                 .padding(.top, 10)
-            Spacer()
+                .padding(.bottom, 20)
+
             Button(action: {
                 model.checkModel.cancelPayment()
                 presentationMode.wrappedValue.dismiss()


### PR DESCRIPTION
Im neuen SwiftUI SupervisorView mit Release 0.29.0 wurden die entsprechenden Infos nicht zur Anzeige integriert.
Dieser Bug wird im Januar eingeführt und ist bisher nicht aufgefallen.

https://snabble.atlassian.net/browse/APPS-1181

### Definition of Done
- [x] Anforderungen erfüllt
- [x] Deployment Target
- [x] Home-Button vs. Face-ID Device (SafeArea Guides)
- [x] Dark / Light Mode
- [x] Product Owner Review
