### PR TITLE
Hinweistexte im Supervisor Checkout nicht vorhanden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * add State to Autonomo session #APPS-1079
 
+### Fixed
+* add text info to SupervisorView #APPS-1181
+
 ### Updated
 * datatrans/ios-sdk 3.3.0 (was 2.7.2)
 

--- a/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
+++ b/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
@@ -31,19 +31,26 @@ struct SupervisorView: View {
     @ViewBuilder
     var content: some View {
         VStack(spacing: 8) {
+            Spacer()
             if let uiImage = model.headerImage {
                 SwiftUI.Image(uiImage: uiImage)
                     .padding([.top, .bottom], 20)
             }
+            Text(Asset.localizedString(forKey: "Snabble.Payment.Online.message"))
+            Spacer()
             if let codeImage = model.codeImage {
                 SwiftUI.Image(uiImage: codeImage)
                     .padding([.top], 20)
             }
-            Spacer()
+            Text(model.idString)
+                .font(.footnote)
+                .padding(.top, 10)
+                .padding(.bottom, 20)
+            
             Button(action: {
                 model.checkModel.cancelPayment()
                 presentationMode.wrappedValue.dismiss()
-           }) {
+            }) {
                 Text(keyed: Asset.localizedString(forKey: "Snabble.cancel"))
                     .fontWeight(.bold)
                     .foregroundColor(Color.accent())

--- a/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
+++ b/Sources/UI/Payment/Checks/SupervisorCheckViewController.swift
@@ -30,23 +30,24 @@ struct SupervisorView: View {
 
     @ViewBuilder
     var content: some View {
-        VStack(spacing: 8) {
+        Group {
             Spacer()
-            if let uiImage = model.headerImage {
-                SwiftUI.Image(uiImage: uiImage)
-                    .padding([.top, .bottom], 20)
+            VStack(spacing: 10) {
+                if let uiImage = model.headerImage {
+                    SwiftUI.Image(uiImage: uiImage)
+                        .padding([.bottom], 20)
+                }
+                Text(Asset.localizedString(forKey: "Snabble.Payment.Online.message"))
             }
-            Text(Asset.localizedString(forKey: "Snabble.Payment.Online.message"))
             Spacer()
-            if let codeImage = model.codeImage {
-                SwiftUI.Image(uiImage: codeImage)
-                    .padding([.top], 20)
+            VStack(spacing: 10) {
+                if let codeImage = model.codeImage {
+                    SwiftUI.Image(uiImage: codeImage)
+                }
+                Text(model.idString)
+                    .font(.footnote)
             }
-            Text(model.idString)
-                .font(.footnote)
-                .padding(.top, 10)
-                .padding(.bottom, 20)
-            
+            Spacer()
             Button(action: {
                 model.checkModel.cancelPayment()
                 presentationMode.wrappedValue.dismiss()
@@ -54,7 +55,7 @@ struct SupervisorView: View {
                 Text(keyed: Asset.localizedString(forKey: "Snabble.cancel"))
                     .fontWeight(.bold)
                     .foregroundColor(Color.accent())
-            }
+            }.frame(alignment: .bottom)
         }
     }
     var body: some View {


### PR DESCRIPTION
Im neuen SwiftUI SupervisorView mit Release 0.29.0 wurden die entsprechenden Infos nicht zur Anzeige integriert. Dieser Bug wird im Januar eingeführt und ist bisher nicht aufgefallen. 

https://snabble.atlassian.net/browse/APPS-1181

### Definition of Done
- [x] Anforderungen erfüllt
- [x] Deployment Target
- [x] Home-Button vs. Face-ID Device (SafeArea Guides)
- [x] Dark / Light Mode
- [x] Product Owner Review
