### PR TITLE
fixes qrcode generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Giropay integration #APPS-1327
+* QRCode Generation for Offline Payment
 
 ### Updated
 * apple/swift-crypto 3.2.0 (was 1.1.7)

--- a/Sources/UI/Payment/EmbeddedCodesCheckoutViewController.swift
+++ b/Sources/UI/Payment/EmbeddedCodesCheckoutViewController.swift
@@ -9,6 +9,7 @@ import DeviceKit
 import SnabbleCore
 
 final class EmbeddedCodesCheckoutViewController: UIViewController {
+    private weak var scrollView: UIScrollView?
     private weak var stackViewLayout: UILayoutGuide?
     private weak var topWrapper: UIView?
     private weak var topIcon: UIImageView?
@@ -82,6 +83,7 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
         scrollView.backgroundColor = .systemBackground
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceVertical = false
+        self.scrollView = scrollView
 
         let contentLayoutGuide = scrollView.contentLayoutGuide
         let frameLayoutGuide = scrollView.frameLayoutGuide
@@ -325,9 +327,7 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
             // all other devices: scale project graphic if needed
             multiplier = 0.6
         }
-        if let stackViewLayout = stackViewLayout {
-            maxScrollViewWidth = stackViewLayout.layoutFrame.width * multiplier
-        }
+        maxScrollViewWidth = self.view.frame.width * multiplier
     }
 
     private func configureCodeScrollView() {
@@ -338,13 +338,13 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
                 codeImages.append(image)
             }
         }
-        maxPageSize = maxCodeSize(for: codeImages, fitting: maxScrollViewWidth)
+        maxPageSize = maxCodeSize(for: codeImages)
 
         scrollView.widthAnchor.constraint(equalToConstant: maxPageSize).isActive = true
         scrollView.heightAnchor.constraint(equalToConstant: maxPageSize).isActive = true
         scrollView.contentSize = CGSize(width: maxPageSize * CGFloat(codes.count), height: scrollView.frame.height)
 
-        for x in 0..<codes.count {
+        for x in 0..<codeImages.count {
             let page = UIImageView()
             page.translatesAutoresizingMaskIntoConstraints = false
             page.contentMode = .scaleAspectFit
@@ -419,7 +419,7 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
 }
 
 extension EmbeddedCodesCheckoutViewController {
-    private func maxCodeSize(for images: [UIImage], fitting width: CGFloat) -> CGFloat {
+    private func maxCodeSize(for images: [UIImage]) -> CGFloat {
         var maxWidth: CGFloat = 0
         for image in codeImages {
             maxWidth = max(maxWidth, image.size.width)
@@ -435,7 +435,7 @@ extension EmbeddedCodesCheckoutViewController {
                 }
             }
         }
-        return nil
+        return QRCode.generate(for: code, scale: 1)
     }
 }
 

--- a/Sources/UI/Payment/EmbeddedCodesCheckoutViewController.swift
+++ b/Sources/UI/Payment/EmbeddedCodesCheckoutViewController.swift
@@ -83,6 +83,7 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
         scrollView.backgroundColor = .systemBackground
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceVertical = false
+        contentView.addSubview(scrollView)
         self.scrollView = scrollView
 
         let contentLayoutGuide = scrollView.contentLayoutGuide
@@ -90,6 +91,7 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
 
         let wrapperView = UIView()
         wrapperView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(wrapperView)
 
         let paidButton = UIButton(type: .system)
         paidButton.translatesAutoresizingMaskIntoConstraints = false
@@ -103,6 +105,7 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
         paidButton.addTarget(self, action: #selector(paidButtonTapped(_:)), for: .touchUpInside)
 
         let stackViewLayout = UILayoutGuide()
+        wrapperView.addLayoutGuide(stackViewLayout)
 
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -147,9 +150,6 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
         pageControl.pageIndicatorTintColor = .systemGray6
         pageControl.currentPageIndicatorTintColor = .black
         pageControl.addTarget(self, action: #selector(pageControlTapped(_:)), for: UIControl.Event.valueChanged)
-
-        contentView.addSubview(scrollView)
-        scrollView.addSubview(wrapperView)
 
         wrapperView.addLayoutGuide(stackViewLayout)
         wrapperView.addSubview(stackView)
@@ -342,7 +342,7 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
 
         scrollView.widthAnchor.constraint(equalToConstant: maxPageSize).isActive = true
         scrollView.heightAnchor.constraint(equalToConstant: maxPageSize).isActive = true
-        scrollView.contentSize = CGSize(width: maxPageSize * CGFloat(codes.count), height: scrollView.frame.height)
+        scrollView.contentSize = CGSize(width: maxPageSize * CGFloat(codeImages.count), height: scrollView.frame.height)
 
         for x in 0..<codeImages.count {
             let page = UIImageView()


### PR DESCRIPTION
- fixes qrcode generation
- add changelog entry

@smancke kam auf mich zu und hat einen Fehler bei der Offline Zahlung mit QRCode gefunden. Ich verstehe noch nicht ganz wie es mal funktionieren konnte, aber hiermit fixe ich das Problem.


1. `maxScrollViewWidth` ist immer 0.0
2. Dadurch werden keine QRCode Images erzeugt
3. Wird bei der Erzeugung für die Images nicht das ImageArray verwendet, sondern das Codes Array, wodurch es zum indexOutOfBounds Fehler kommt