### PR TITLE
Kassenbon kann nicht geschlossen werden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # OS X
 .DS_Store
 
+# Environment Variables
+.env
+
 # Xcode
 build/
 .build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.46]
 
+### Fixed
+* Receipt view on checkout has no navigation bar #APPS-1380
+
 ## [0.45] - 2024-02-21
 
 ### Fixed

--- a/Sources/UI/Checkout/CheckoutStepsViewController.swift
+++ b/Sources/UI/Checkout/CheckoutStepsViewController.swift
@@ -237,7 +237,7 @@ final class CheckoutStepsViewController: UIHostingController<CheckoutView> {
             }
             if let receiptLink = userInfo["receiptLink"] as? SnabbleCore.Link, let url = URL(string: receiptLink.href) {
                 let detailViewController = ReceiptsDetailViewController(orderId: url.lastPathComponent, projectId: viewModel.shop.projectId)
-                present(detailViewController, animated: true)
+                navigationController?.pushViewController(detailViewController, animated: true)
                 return
             }
         }


### PR DESCRIPTION
pushViewController for receipts on checkout instead of present view controller

Test instructions:
- use SnabbleApp 
- add a credit card (VISA)
- make a purchase
- on checkout screen tap on CheckoutStepView "Receipt" 

https://snabble.atlassian.net/browse/APPS-1380

### Definition of Done
- [x] Anforderungen erfüllt
- [x] Deployment Target
- [x] Home-Button vs. Face-ID Device (SafeArea Guides)
- [x] Dark / Light Mode
- [ ] Product Owner Review
