### PR TITLE
Set protection level to public for invalidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 * Persönliche Daten beim Anlegen einer Bezahlmethode einbinden #APPS-1356
 * Rechnungskauf Zusatzfeld pro Projekt begrenzen #APPS-1491
+* Set Protection Level of `TokenRegistry.invalidate()` to public #APPS-1479
 
 ### Updated
 * groue/GRDB.swift 6.26.0 (was 6.25.0)

--- a/Sources/Core/API/Snabble.swift
+++ b/Sources/Core/API/Snabble.swift
@@ -507,7 +507,7 @@ extension Snabble {
             keychain[appUserKey] = newValue?.stringRepresentation
             UserDefaults.standard.set(newValue?.value, forKey: "Snabble.api.appUserId")
 
-            tokenRegistry.invalidateAllTokens()
+            tokenRegistry.invalidate()
             OrderList.clearCache()
         }
     }

--- a/Sources/Core/API/TokenRegistry.swift
+++ b/Sources/Core/API/TokenRegistry.swift
@@ -137,7 +137,7 @@ public final class TokenRegistry {
     }
 
     // invalidate all tokens - called when the appUser changes
-    func invalidateAllTokens() {
+    public func invalidate() {
         self.refreshTimer?.invalidate()
 
         let activeIds: [Identifier<Project>] = lock.writing {


### PR DESCRIPTION
* `invalidate` method of `TokenRegistry` needs to be public to fix APPS-1479