### PR TITLE
Add State client_exited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 * Injectable placeholder view for emtpy receipts #APPS-1526
 * Set Deployment Target to iOS 15
+* Add AutonomoState `client_exited` #APPS-921
 
 ### Updated
 * weichsel/ZIPFoundation 0.9.19 (was 0.9.18)

--- a/Sources/Core/Metadata/EntryToken/Autonomo+EntryToken.swift
+++ b/Sources/Core/Metadata/EntryToken/Autonomo+EntryToken.swift
@@ -18,6 +18,7 @@ public enum Autonomo {
         case clientEntering = "client_entering"
         case clientEntered = "client_entered"
         case clientLeft = "client_left"
+        case clientExited = "client_exited"
         case cartCompleted = "cart_completed"
         case cartPaid = "cart_paid"
         case paymentFailed = "payment_failed"


### PR DESCRIPTION
Der State `client_exited` wird laut @mschewe in der Polling API hinzugefügt.

https://snabble.slack.com/archives/C06078ATBBN/p1713960810008759

Zusatz zu https://snabble.atlassian.net/browse/APPS-921