### PR TITLE
[ScanAndGo] Fix: `BarcodeSearchRowView` can only be selected on the text area.

### DIFF
--- a/ScanAndGo/Shopping/Views/BarcodeSearchView.swift
+++ b/ScanAndGo/Shopping/Views/BarcodeSearchView.swift
@@ -23,15 +23,13 @@ struct BarcodeSearchRowView: View {
         return codeEntry.code
     }
     var body: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text(codeString)
-                Text(product.name)
-                    .font(.caption)
-            }
-            Spacer()
+        VStack(alignment: .leading) {
+            Text(codeString)
+            Text(product.name)
+                .font(.caption)
         }
-        .contentShape(Rectangle())
+        .padding(.horizontal)
+        .containerRelativeFrame(.horizontal, alignment: .leading)
         .task {
             update()
         }

--- a/ScanAndGo/Shopping/Views/BarcodeSearchView.swift
+++ b/ScanAndGo/Shopping/Views/BarcodeSearchView.swift
@@ -30,6 +30,7 @@ struct BarcodeSearchRowView: View {
         }
         .padding(.horizontal)
         .containerRelativeFrame(.horizontal, alignment: .leading)
+        .contentShape(Rectangle())
         .task {
             update()
         }

--- a/ScanAndGo/Shopping/Views/BarcodeSearchView.swift
+++ b/ScanAndGo/Shopping/Views/BarcodeSearchView.swift
@@ -23,10 +23,13 @@ struct BarcodeSearchRowView: View {
         return codeEntry.code
     }
     var body: some View {
-        VStack(alignment: .leading) {
-            Text(codeString)
-            Text(product.name)
-                .font(.caption)
+        HStack {
+            VStack(alignment: .leading) {
+                Text(codeString)
+                Text(product.name)
+                    .font(.caption)
+            }
+            Spacer()
         }
         .contentShape(Rectangle())
         .task {
@@ -88,7 +91,6 @@ struct BarcodeSearchView: View {
             List(searchResults, selection: $selection) { value in
                 BarcodeSearchRowView(product: value, searchText: $searchText)
                     .id(value.id)
-                    .contentShape(Rectangle())
                     .onTapGesture {
                         selection = value
                     }


### PR DESCRIPTION
Please check with SnabbleScanAndGo package enabled app (VR)