### PR TITLE
[Scan&Go] Fixes "No scanned Item" Message after adding item to the cart

### DIFF
--- a/Core/Sources/API/SDKVersion.swift
+++ b/Core/Sources/API/SDKVersion.swift
@@ -5,5 +5,5 @@
 //
 
 public var SDKVersion: String {
-    "0.55.0"
+    "0.56.0"
 }

--- a/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
+++ b/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
@@ -257,14 +257,14 @@ struct ScannedItemEditorView: View {
                     scannedItem: scannedItem,
                     onDismiss: onDismiss,
                     onAdd: { cartItem in
-                        self.updateCartItem(cartItem)
+                        updateCartItem(cartItem)
                     })
             }
         }
         .padding(.bottom, (keyboardHeight > 0 ? keyboardHeight + 80 : 150))
     }
     
-    func updateCartItem(_ cartItem: CartItem) {
+    private func updateCartItem(_ cartItem: CartItem) {
         model.updateCartItem(cartItem)
         onDismiss()
     }

--- a/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
+++ b/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
@@ -246,7 +246,7 @@ struct ScannerCartItemView: View {
 struct ScannedItemEditorView: View {
     @SwiftUI.Environment(\.keyboardHeight) var keyboardHeight
     @ObservedObject var model: Shopper
-    @Binding var isPresented: Bool
+    var onDismiss: () -> Void
     
     var body: some View {
         VStack {
@@ -255,9 +255,7 @@ struct ScannedItemEditorView: View {
                 ScannerCartItemView(
                     model: model,
                     scannedItem: scannedItem,
-                    onDismiss: {
-                        dismiss()
-                    },
+                    onDismiss: onDismiss,
                     onAdd: { cartItem in
                         self.updateCartItem(cartItem)
                     })
@@ -268,12 +266,6 @@ struct ScannedItemEditorView: View {
     
     func updateCartItem(_ cartItem: CartItem) {
         model.updateCartItem(cartItem)
-        dismiss()
-    }
-    
-    func dismiss() {
-        withAnimation {
-            isPresented = false
-        }
+        onDismiss()
     }
 }

--- a/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
+++ b/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
@@ -138,11 +138,11 @@ struct ScannerQuantityView: View {
 }
 
 struct ScannerCartItemView: View {
-    @SwiftUI.Environment(\.dismiss) var dismiss
     @ObservedObject var model: Shopper
     
     let scannedItem: BarcodeManager.ScannedItem
-    let onAction: (_: CartItem?) -> Void
+    let onDismiss: () -> Void
+    let onAdd: (_ cartItem: CartItem) -> Void
     let alreadyInCart: Bool
     
     @State private var cartItem: CartItem
@@ -155,11 +155,13 @@ struct ScannerCartItemView: View {
     
     init(model: Shopper,
          scannedItem: BarcodeManager.ScannedItem,
-         onAction: @escaping (_: CartItem?) -> Void
+         onDismiss: @escaping () -> Void,
+         onAdd: @escaping (_ cartItem: CartItem) -> Void
     ) {
         self.model = model
         self.scannedItem = scannedItem
-        self.onAction = onAction
+        self.onAdd = onAdd
+        self.onDismiss = onDismiss
         
         let result = model.cartItem(for: scannedItem)
         var cartItem = result.cartItem
@@ -178,8 +180,7 @@ struct ScannerCartItemView: View {
         VStack {
             VStack(spacing: 6) {
                 Button(action: {
-                    onAction(nil)
-                    dismiss()
+                    onDismiss()
                 }) {
                     SwiftUI.Image(systemName: "xmark")
                         .font(.title2)
@@ -216,10 +217,7 @@ struct ScannerCartItemView: View {
                 let title = alreadyInCart ? Asset.localizedString(forKey: "Snabble.Scanner.updateCart") : Asset.localizedString(forKey: "Snabble.Scanner.addToCart")
                 
                 PrimaryButtonView(title: title, disabled: $disableCheckout, onAction: {
-                    dismiss()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                        onAction(self.cartItem)
-                    }
+                    onAdd(cartItem)
                 })
                 .padding()
             }
@@ -257,21 +255,23 @@ struct ScannedItemEditorView: View {
                 ScannerCartItemView(
                     model: model,
                     scannedItem: scannedItem,
-                    onAction: { cartItem in
+                    onDismiss: {
+                        dismiss()
+                    },
+                    onAdd: { cartItem in
                         self.updateCartItem(cartItem)
                     })
-            } else {
-                Text("No scanned item!")
-                    .font(.title)
-                    .foregroundStyle(.secondary)
             }
         }
         .padding(.bottom, (keyboardHeight > 0 ? keyboardHeight + 80 : 150))
     }
-    func updateCartItem(_ cartItem: CartItem?) {
-        if let cartItem {
-            model.updateCartItem(cartItem)
-        }
+    
+    func updateCartItem(_ cartItem: CartItem) {
+        model.updateCartItem(cartItem)
+        dismiss()
+    }
+    
+    func dismiss() {
         withAnimation {
             isPresented = false
         }

--- a/ScanAndGo/Shopping/Views/ShopperView.swift
+++ b/ScanAndGo/Shopping/Views/ShopperView.swift
@@ -38,7 +38,9 @@ public struct ShopperView: View {
                 Text(model.errorMessage ?? "No errorMessage! This should not happen! 😳")
             }
             .dialog(isPresented: $showEditor) {
-                ScannedItemEditorView(model: model, isPresented: $showEditor)
+                ScannedItemEditorView(model: model) {
+                    showEditor = false
+                }
             }
             .keyboardHeightEnvironmentValue()
             .sheet(isPresented: $showSearch) {


### PR DESCRIPTION
* Removes `Text()` if `scannedItem` is `nil`
* adds unique methods for add item and dismiss view