### PR TITLE
Readd deprecated `traitCollectionDidChange` methods

### DIFF
--- a/UI/Sources/Coupons/CouponsViewController.swift
+++ b/UI/Sources/Coupons/CouponsViewController.swift
@@ -41,10 +41,6 @@ public final class CouponsViewController: UICollectionViewController {
         configureCollectionView(collectionView)
         configureEmptyLabel(on: collectionView)
         update(with: coupons)
-        
-        registerForTraitChanges([UITraitUserInterfaceStyle.self], handler: { (self: Self, _: UITraitCollection) in
-            self.update(with: self.coupons)
-        })
     }
 
     private func configureCollectionView(_ collectionView: UICollectionView) {
@@ -62,6 +58,11 @@ public final class CouponsViewController: UICollectionViewController {
         emptyLabel.isHidden = false
         collectionView.backgroundView = emptyLabel
         self.emptyLabel = emptyLabel
+    }
+    
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        update(with: coupons)
     }
 
     private func update(with coupons: [Coupon]) {

--- a/UI/Sources/Payment/CustomerCardCheckoutViewController.swift
+++ b/UI/Sources/Payment/CustomerCardCheckoutViewController.swift
@@ -191,9 +191,6 @@ final class CustomerCardCheckoutViewController: UIViewController {
         iconWrapper?.isHidden = true
 
         setupIcons()
-        registerForTraitChanges([UITraitUserInterfaceStyle.self], handler: { (self: Self, _: UITraitCollection) in
-            self.setupIcons()
-        })
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -223,6 +220,11 @@ final class CustomerCardCheckoutViewController: UIViewController {
         super.viewWillDisappear(animated)
 
         UIScreen.main.brightness = self.initialBrightness
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setupIcons()
     }
 
     private func setupIcons() {

--- a/UI/Sources/Payment/EmbeddedCodesCheckoutViewController.swift
+++ b/UI/Sources/Payment/EmbeddedCodesCheckoutViewController.swift
@@ -260,10 +260,6 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
         configureCodeScrollView()
 
         codeScrollView?.delegate = self
-        
-        registerForTraitChanges([UITraitUserInterfaceStyle.self], handler: { (self: Self, _: UITraitCollection) in
-            self.setupIcon()
-        })
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -298,6 +294,11 @@ final class EmbeddedCodesCheckoutViewController: UIViewController {
             // user "aborted" this payment process by tapping 'Back'
             cart.generateNewUUID()
         }
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setupIcon()
     }
 
     private func configureViewForDevice() {

--- a/UI/Sources/Scanner/ScannerDrawerViewController.swift
+++ b/UI/Sources/Scanner/ScannerDrawerViewController.swift
@@ -161,7 +161,6 @@ final class ScannerDrawerViewController: UIViewController {
         view.backgroundColor = .clear
         self.shoppingListTableVC.view.backgroundColor = .clear
         self.shoppingCartVC.view.backgroundColor = .clear
-        setupBlurEffect()
 
         checkoutBar?.shoppingCartDelegate = shoppingCartDelegate
 
@@ -171,9 +170,14 @@ final class ScannerDrawerViewController: UIViewController {
         nc.addObserver(self, selector: #selector(self.shoppingCartUpdated(_:)), name: .snabbleCartUpdated, object: nil)
       
         registerForTraitChanges([UITraitUserInterfaceStyle.self], handler: { (self: Self, _: UITraitCollection) in
-            self.setupBlurEffect()
+            self.setupBlurEffect(forTraitCollection: self.traitCollection)
         })
    }
+    
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
+        setupBlurEffect(forTraitCollection: traitCollection)
+    }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -183,8 +187,8 @@ final class ScannerDrawerViewController: UIViewController {
         checkoutBar?.updateTotals()
     }
 
-    private func setupBlurEffect() {
-        self.effectView?.effect = UIBlurEffect(style: traitCollection.userInterfaceStyle == .light ? .extraLight : .dark)
+    private func setupBlurEffect(forTraitCollection traitCollection: UITraitCollection) {
+        effectView?.effect = UIBlurEffect(style: traitCollection.userInterfaceStyle == .light ? .extraLight : .dark)
     }
 
     @objc private func handleTapped(_ gesture: UITapGestureRecognizer) {


### PR DESCRIPTION
We didn't verify the usage. We have to check every single case and verify which trait is relevant.

In `UI/Sources/Scanner/ScannerDrawerViewController.swift` I was able to identify which trait is important and directly use it.