### PR TITLE
[ScanAndGo] Fixes navigation bug after checkout screen

### DIFF
--- a/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -2,7 +2,7 @@ name: LicensePlist, nameSpecified: , owner: mono0926, version: 3.25.1, source: h
 
 name: SwiftLint, nameSpecified: , owner: realm, version: main, source: https://github.com/realm/SwiftLint
 
-name: DeviceKit, nameSpecified: DeviceKit, owner: devicekit, version: 5.4.0, source: https://github.com/devicekit/DeviceKit
+name: DeviceKit, nameSpecified: DeviceKit, owner: devicekit, version: 5.5.0, source: https://github.com/devicekit/DeviceKit
 
 name: GRDB.swift, nameSpecified: GRDB.swift, owner: groue, version: 6.29.3, source: https://github.com/groue/GRDB.swift
 

--- a/ScanAndGo/Shopping/Models/Shopper.swift
+++ b/ScanAndGo/Shopping/Models/Shopper.swift
@@ -187,7 +187,7 @@ public final class Shopper: ObservableObject, BarcodeProcessing, Equatable {
     }
     @Published public var isNavigating: Bool = false {
         didSet {
-            if isNavigating == false {
+            if !isNavigating {
                 controller = nil
                 self.startScanner()
             }

--- a/ScanAndGo/Shopping/Models/Shopper.swift
+++ b/ScanAndGo/Shopping/Models/Shopper.swift
@@ -185,7 +185,22 @@ public final class Shopper: ObservableObject, BarcodeProcessing, Equatable {
             barcodeManager.barcodeDetector.setTorch(flashlight)
         }
     }
-    @Published public var controller: UIViewController?
+    @Published public var isNavigating: Bool = false {
+        didSet {
+            if isNavigating == false {
+                controller = nil
+                self.startScanner()
+            }
+        }
+    }
+    @Published public var controller: UIViewController? {
+        didSet {
+            if controller != nil {
+                self.stopScanner()
+                isNavigating = true
+            }
+        }
+    }
     
     /// Resets the scan data.
     public func reset() {

--- a/ScanAndGo/Shopping/Views/ShopperView.swift
+++ b/ScanAndGo/Shopping/Views/ShopperView.swift
@@ -18,7 +18,6 @@ public struct ShopperView: View {
     @State private var showSearch: Bool = false
     @State private var showError: Bool = false
     @State private var showEditor: Bool = false
-    @State private var showDialog: Bool = false
     @State private var minHeight: CGFloat = 0
     
     public init(model: Shopper) {
@@ -28,8 +27,8 @@ public struct ShopperView: View {
     public var body: some View {
         ShoppingScannerView(model: model, minHeight: $minHeight)
             .animation(.easeInOut, value: model.scannedItem)
-            .navigationDestination(isPresented: $showDialog) {
-                model.navigationDestination(isPresented: $showDialog)
+            .navigationDestination(isPresented: $model.isNavigating) {
+                model.navigationDestination(isPresented: $model.isNavigating)
             }
             .alert(Asset.localizedString(forKey: "Snabble.SaleStop.ErrorMsg.title"), isPresented: $showError) {
                 Button(Asset.localizedString(forKey: "Snabble.ok")) {
@@ -72,20 +71,6 @@ public struct ShopperView: View {
                     withAnimation {
                         showEditor = true
                     }
-                }
-            }
-            .onReceive(model.$controller) { controller in
-                if controller != nil {
-                    model.stopScanner()
-                    withAnimation {
-                        showDialog = true
-                    }
-                }
-            }
-            .onChange(of: showDialog) {
-                if !showDialog {
-                    model.controller = nil
-                    model.startScanner()
                 }
             }
             .onChange(of: showEditor) {

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -9,11 +9,7 @@ import SwiftUI
 
 public struct ContainerView: UIViewControllerRepresentable {
     public let viewController: UIViewController
-    @Binding public var isPresented: Bool {
-        didSet {
-            print("ContactView: isPresented: \(isPresented)")
-        }
-    }
+    @Binding public var isPresented: Bool
     
     public init(viewController: UIViewController, isPresented: Binding<Bool>) {
         self.viewController = viewController

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -9,15 +9,18 @@ import SwiftUI
 
 public struct ContainerView: UIViewControllerRepresentable {
     public let viewController: UIViewController
+    
     @Binding public var isPresented: Bool
     
     public init(viewController: UIViewController, isPresented: Binding<Bool>) {
         self.viewController = viewController
         self._isPresented = isPresented
     }
+    
     public func makeUIViewController(context: Context) -> UIViewController {
         return ContainerViewController(coordinator: context.coordinator)
     }
+    
     public func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
     }
@@ -31,16 +34,18 @@ public struct ContainerView: UIViewControllerRepresentable {
         init(parent: ContainerView) {
             self.parent = parent
         }
+        
         var viewController: UIViewController {
             parent.viewController
         }
+        
         func close() {
             parent.isPresented = false
         }
     }
     
     class ContainerViewController: UIViewController {
-        let coordinator: Coordinator
+        private let coordinator: Coordinator
         
         init(coordinator: Coordinator) {
             self.coordinator = coordinator
@@ -54,6 +59,7 @@ public struct ContainerView: UIViewControllerRepresentable {
         var viewController: UIViewController {
             coordinator.viewController
         }
+        
         override func viewDidLoad() {
             super.viewDidLoad()
                         
@@ -69,8 +75,9 @@ public struct ContainerView: UIViewControllerRepresentable {
                 viewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
         }
-        override func viewWillDisappear(_ animated: Bool) {
-            super.viewWillDisappear(animated)
+        
+        override func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
             coordinator.close()
         }
     }

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -35,12 +35,12 @@ public struct ContainerView: UIViewControllerRepresentable {
             self.parent = parent
         }
         
-        var viewController: UIViewController {
-            parent.viewController
+        deinit {
+            parent.isPresented = false
         }
         
-        func close() {
-            parent.isPresented = false
+        var viewController: UIViewController {
+            parent.viewController
         }
     }
     
@@ -51,9 +51,7 @@ public struct ContainerView: UIViewControllerRepresentable {
             self.coordinator = coordinator
             super.init(nibName: nil, bundle: nil)
         }
-        deinit {
-            coordinator.close()
-        }
+        
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -55,11 +55,12 @@ public struct ContainerView: UIViewControllerRepresentable {
             fatalError("init(coder:) has not been implemented")
         }
         
+        var viewController: UIViewController {
+            coordinator.viewController
+        }
         override func viewDidLoad() {
             super.viewDidLoad()
-            
-            let viewController = coordinator.viewController
-            
+                        
             addChild(viewController)
             view.addSubview(viewController.view)
             viewController.didMove(toParent: self)

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -77,10 +77,5 @@ public struct ContainerView: UIViewControllerRepresentable {
                 viewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
         }
-        
-//        override func viewDidDisappear(_ animated: Bool) {
-//            super.viewDidDisappear(animated)
-//            coordinator.close()
-//        }
     }
 }

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -52,5 +52,15 @@ public struct ContainerView: UIViewControllerRepresentable {
                 childViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
         }
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            print("container view did appear")
+        }
+
+        override func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
+            print("container view did disappear")
+            isPresented = false
+        }
     }
 }

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -51,7 +51,9 @@ public struct ContainerView: UIViewControllerRepresentable {
             self.coordinator = coordinator
             super.init(nibName: nil, bundle: nil)
         }
-        
+        deinit {
+            coordinator.close()
+        }
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
@@ -76,9 +78,9 @@ public struct ContainerView: UIViewControllerRepresentable {
             ])
         }
         
-        override func viewDidDisappear(_ animated: Bool) {
-            super.viewDidDisappear(animated)
-            coordinator.close()
-        }
+//        override func viewDidDisappear(_ animated: Bool) {
+//            super.viewDidDisappear(animated)
+//            coordinator.close()
+//        }
     }
 }


### PR DESCRIPTION
The function .deinit() is called in the deinit method of the ContainerViewController, otherwise the navigation will break.