### PR TITLE
Refactor GenericDialog to WindowDialog

### DIFF
--- a/Components/Sources/SwiftUI/View/Dialog/WindowDialog.swift
+++ b/Components/Sources/SwiftUI/View/Dialog/WindowDialog.swift
@@ -29,7 +29,7 @@ public struct WindowDialog<DialogContent: View>: ViewModifier {
         content
             .windowCover(isPresented: $isPresented) {
                 ZStack {
-                    Color.black.opacity(0.2)
+                    Color.black.opacity(0.3)
                         .ignoresSafeArea()
                         .onTapGesture {
                             isPresented = false

--- a/Components/Sources/SwiftUI/View/Dialog/WindowDialog.swift
+++ b/Components/Sources/SwiftUI/View/Dialog/WindowDialog.swift
@@ -10,7 +10,7 @@ import UIKit
 import Combine
 import WindowKit
 
-public struct GenericDialog<DialogContent: View>: ViewModifier {
+public struct WindowDialog<DialogContent: View>: ViewModifier {
     @Binding var isPresented: Bool
     let duration: TimeInterval?
     let dialogContent: DialogContent
@@ -74,7 +74,7 @@ public extension View {
         isPresented: Binding<Bool>,
         duration: TimeInterval? = nil,
         @ViewBuilder content: @escaping () -> DialogContent) -> some View {
-            modifier(GenericDialog(
+            modifier(WindowDialog(
                 isPresented: isPresented,
                 duration: duration,
                 content: content)

--- a/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -26,6 +26,12 @@ name: TrustKit, nameSpecified: TrustKit, owner: datatheorem, version: 3.0.4, sou
 
 name: WCAG-Colors, nameSpecified: WCAG-Colors, owner: chrs1885, version: 1.0.0, source: https://github.com/chrs1885/WCAG-Colors
 
+name: WindowKit, nameSpecified: WindowKit, owner: divadretlaw, version: 2.5.2, source: https://github.com/divadretlaw/WindowKit
+
+name: WindowReader, nameSpecified: WindowReader, owner: divadretlaw, version: 2.0.1, source: https://github.com/divadretlaw/WindowReader
+
+name: WindowSceneReader, nameSpecified: WindowSceneReader, owner: divadretlaw, version: 3.1.2, source: https://github.com/divadretlaw/WindowSceneReader
+
 name: ZIPFoundation, nameSpecified: ZIPFoundation, owner: weichsel, version: 0.9.19, source: https://github.com/weichsel/ZIPFoundation
 
 add-version-numbers: false

--- a/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -124,6 +124,30 @@
 		</dict>
 		<dict>
 			<key>File</key>
+			<string>com.mono0926.LicensePlist/WindowKit</string>
+			<key>Title</key>
+			<string>WindowKit</string>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+		</dict>
+		<dict>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist/WindowReader</string>
+			<key>Title</key>
+			<string>WindowReader</string>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+		</dict>
+		<dict>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist/WindowSceneReader</string>
+			<key>Title</key>
+			<string>WindowSceneReader</string>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+		</dict>
+		<dict>
+			<key>File</key>
 			<string>com.mono0926.LicensePlist/ZIPFoundation</string>
 			<key>Title</key>
 			<string>ZIPFoundation</string>

--- a/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist/WindowKit.plist
+++ b/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist/WindowKit.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>MIT License
+
+Copyright (c) 2024 David Walter (davidwalter.at)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</string>
+			<key>License</key>
+			<string>MIT</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist/WindowReader.plist
+++ b/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist/WindowReader.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>MIT License
+
+Copyright (c) 2024 David Walter (davidwalter.at)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</string>
+			<key>License</key>
+			<string>MIT</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist/WindowSceneReader.plist
+++ b/Example/Snabble/Settings.bundle/com.mono0926.LicensePlist/WindowSceneReader.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>MIT License
+
+Copyright (c) 2024 David Walter (davidwalter.at)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</string>
+			<key>License</key>
+			<string>MIT</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dd4e081d874fa70b27cdbab87ce9cca0b23a77473c1cbf1ba5dfec0afb1d0c5c",
+  "originHash" : "350131f85fa163617ff2e4c6922c71c5c85c6fdc637704f7cca300b7ba5e23ff",
   "pins" : [
     {
       "identity" : "devicekit",
@@ -107,6 +107,33 @@
       "state" : {
         "revision" : "b7f44fad81e8e17da7e6201265e1288e088e57f3",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "windowkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/divadretlaw/WindowKit",
+      "state" : {
+        "revision" : "d9a7d0fffaf1ddf390f88f5a0d1cd970df8d0309",
+        "version" : "2.5.2"
+      }
+    },
+    {
+      "identity" : "windowreader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/divadretlaw/WindowReader",
+      "state" : {
+        "revision" : "295d4e6c1aacd3c6a79e47c70f7b2745b8e0399e",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "windowscenereader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/divadretlaw/WindowSceneReader",
+      "state" : {
+        "revision" : "1f37f310e15a9a58014f2dbfce29526e5f3f4567",
+        "version" : "3.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,8 @@ let package = Package(
         .package(url: "https://github.com/snabble/Pulley.git", from: "2.9.2"),
         .package(url: "https://github.com/chrs1885/WCAG-Colors.git", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.10.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.1")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
+        .package(url: "https://github.com/divadretlaw/WindowKit", from: "2.5.2")
     ],
     targets: [
         .target(
@@ -136,7 +137,8 @@ let package = Package(
         .target(
             name: "SnabbleComponents",
             dependencies: [
-                "SnabbleAssetProviding"
+                "SnabbleAssetProviding",
+                "WindowKit"
             ],
             path: "Components/Sources"
         ),


### PR DESCRIPTION
* Uses [`WindowKit`](https://github.com/divadretlaw/WindowKit) to display a view from any SwiftUI View
* Replaces `fullscreenCover` with `windowCover`
* Set custom modal transition to fade-in and -out