### PR TITLE
[ScanAndGo] Uses the `.bottomSheet` modifier for the selection of payment methods

### DIFF
--- a/Components/Sources/SwiftUI/View/ContainerView.swift
+++ b/Components/Sources/SwiftUI/View/ContainerView.swift
@@ -9,56 +9,28 @@ import SwiftUI
 
 public struct ContainerView: UIViewControllerRepresentable {
     public let viewController: UIViewController
-    
-    @Binding public var isPresented: Bool
-    
+        
     public init(viewController: UIViewController) {
         self.viewController = viewController
-        self._isPresented = .constant(true)
     }
-    
-    public init(viewController: UIViewController, isPresented: Binding<Bool>) {
-        self.viewController = viewController
-        self._isPresented = isPresented
-    }
-    
+        
     public func makeUIViewController(context: Context) -> UIViewController {
-        return ContainerViewController(coordinator: context.coordinator)
+        return ContainerViewController(viewController: viewController)
     }
     
-    public func makeCoordinator() -> Coordinator {
-        Coordinator(parent: self)
-    }
-
     // swiftlint:disable:next no_empty_block
     public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
     
-    public class Coordinator: NSObject {
-        let parent: ContainerView
-        
-        init(parent: ContainerView) {
-            self.parent = parent
-        }
-                
-        var viewController: UIViewController {
-            parent.viewController
-        }
-    }
-    
     class ContainerViewController: UIViewController {
-        private let coordinator: Coordinator
-        
-        init(coordinator: Coordinator) {
-            self.coordinator = coordinator
+        public let viewController: UIViewController
+
+        init(viewController: UIViewController) {
+            self.viewController = viewController
             super.init(nibName: nil, bundle: nil)
         }
         
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
-        }
-        
-        var viewController: UIViewController {
-            coordinator.viewController
         }
         
         override func viewDidLoad() {

--- a/Components/Sources/SwiftUI/View/Dialog/BottomSheet.swift
+++ b/Components/Sources/SwiftUI/View/Dialog/BottomSheet.swift
@@ -14,7 +14,6 @@ public struct BottomSheet<DialogContent: View>: ViewModifier {
     @Binding var isPresented: Bool
     let dialogContent: DialogContent
     
-    @State private var workItem: DispatchWorkItem?
     @State private var showContent: Bool = false
     
     public init(isPresented: Binding<Bool>,

--- a/Components/Sources/SwiftUI/View/Dialog/BottomSheet.swift
+++ b/Components/Sources/SwiftUI/View/Dialog/BottomSheet.swift
@@ -1,0 +1,66 @@
+//
+//  BottomSheet.swift
+//  Snabble
+//
+//  Created by Uwe Tilemann on 23.10.24.
+//
+
+import SwiftUI
+import UIKit
+import Combine
+import WindowKit
+
+public struct BottomSheet<DialogContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let dialogContent: DialogContent
+    
+    @State private var workItem: DispatchWorkItem?
+    @State private var showContent: Bool = false
+    
+    public init(isPresented: Binding<Bool>,
+                @ViewBuilder content: () -> DialogContent) {
+        _isPresented = isPresented
+        self.dialogContent = content()
+    }
+    
+    public func body(content: Content) -> some View {
+        content
+            .windowCover(isPresented: $isPresented) {
+                ZStack {
+                    Color.black.opacity(0.3)
+                        .ignoresSafeArea()
+                        .onAppear {
+                            showContent = true
+                        }
+                        .windowCover(isPresented: $showContent) {
+                            ZStack {
+                                Color.black.opacity(0.001)
+                                    .ignoresSafeArea()
+                                    .onTapGesture {
+                                        showContent = false
+                                        isPresented = false
+                                    }
+                                VStack {
+                                    Spacer()
+                                    dialogContent
+                                }
+                            }
+                        }
+                }
+            } configure: { configuration in
+                configuration.modalPresentationStyle = .custom
+                configuration.modalTransitionStyle = .crossDissolve
+            }
+    }
+}
+
+public extension View {
+    func bottomSheet<DialogContent: View>(
+        isPresented: Binding<Bool>,
+        @ViewBuilder content: @escaping () -> DialogContent) -> some View {
+            modifier(BottomSheet(
+                isPresented: isPresented,
+                content: content)
+            )
+        }
+}

--- a/Components/Sources/SwiftUI/View/Dialog/BottomSheet.swift
+++ b/Components/Sources/SwiftUI/View/Dialog/BottomSheet.swift
@@ -27,29 +27,33 @@ public struct BottomSheet<DialogContent: View>: ViewModifier {
         content
             .windowCover(isPresented: $isPresented) {
                 ZStack {
-                    Color.black.opacity(0.3)
+                    Color.black.opacity(0.25)
                         .ignoresSafeArea()
                         .onAppear {
                             showContent = true
-                        }
-                        .windowCover(isPresented: $showContent) {
-                            ZStack {
-                                Color.black.opacity(0.001)
-                                    .ignoresSafeArea()
-                                    .onTapGesture {
-                                        showContent = false
-                                        isPresented = false
-                                    }
-                                VStack {
-                                    Spacer()
-                                    dialogContent
-                                }
-                            }
                         }
                 }
             } configure: { configuration in
                 configuration.modalPresentationStyle = .custom
                 configuration.modalTransitionStyle = .crossDissolve
+            }
+            .windowCover(isPresented: $showContent) {
+                ZStack {
+                    Color.black.opacity(0.001)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            isPresented = false
+                        }
+                    VStack {
+                        Spacer()
+                        dialogContent
+                    }
+                }
+            }
+            .onChange(of: isPresented) {
+                if !isPresented, showContent {
+                    showContent = false
+                }
             }
     }
 }

--- a/Core/Sources/Cart/ShoppingCart.swift
+++ b/Core/Sources/Cart/ShoppingCart.swift
@@ -22,6 +22,10 @@ public final class ShoppingCart: Codable {
         }
     }
     public private(set) var paymentMethods: [PaymentMethodDescription]?
+    public var supportedPayments: [RawPaymentMethod]? {
+        paymentMethods?.map { $0.method }
+    }
+    
     public private(set) var lastCheckoutInfoError: SnabbleError?
     public private(set) var coupons: [CartCoupon]
 

--- a/ScanAndGo/Shopping/Models/ActionState.swift
+++ b/ScanAndGo/Shopping/Models/ActionState.swift
@@ -22,8 +22,6 @@ public enum ActionType: Equatable {
     case dialog(any View)
     /// Shows a `View` full screen, using `.sheet(isPresenting:) {}`
     case sheet(any View)
-    /// Shows the given associated `SheetProviding`
-    case alertSheet(SheetProviding)
     /// Shows the given associated `Alert`
     case alert(Alert)
     
@@ -50,8 +48,6 @@ extension ActionType: CustomStringConvertible {
             "dialog"
         case .sheet:
             "sheet"
-        case .alertSheet:
-            "alertSheet"
         case .alert:
             "alert"
         }
@@ -140,7 +136,6 @@ public struct ActionModifier: ViewModifier {
     
     @State var dialogPresented: Bool = false
     @State var sheetPresented: Bool = false
-    @State var alertSheetPresented: Bool = false
     @State var alertPresented: Bool = false
     
     @ViewBuilder var dialogView: some View {
@@ -150,19 +145,12 @@ public struct ActionModifier: ViewModifier {
             ErrorText(reason: "No dialogView to be displayed.")
         }
     }
+    
     @ViewBuilder var sheetView: some View {
         if case .sheet(let view) = actionState {
             AnyView(view)
         } else {
             ErrorText(reason: "No sheetView to be displayed.")
-        }
-    }
-    @ViewBuilder var alertSheetView: some View {
-        if case .alertSheet(let sheetProvider) = actionState {
-            let sheet = sheetProvider.sheetController { }
-            ContainerView(viewController: sheet, isPresented: $alertSheetPresented)
-        } else {
-            ErrorText(reason: "No alertSheet to be displayed.")
         }
     }
     
@@ -174,7 +162,6 @@ public struct ActionModifier: ViewModifier {
             toast = nil
             dialogPresented = false
             sheetPresented = false
-            alertSheetPresented = false
             alertPresented = false
             
         case .toast(let toast):
@@ -183,8 +170,6 @@ public struct ActionModifier: ViewModifier {
             dialogPresented = true
         case .sheet:
             sheetPresented = true
-        case .alertSheet:
-            alertSheetPresented = true
         case .alert:
             alertPresented = true
         }
@@ -214,12 +199,6 @@ public struct ActionModifier: ViewModifier {
                 resetState(sheetPresented)
             }
         
-            .windowDialog(isPresented: $alertSheetPresented) {
-                alertSheetView
-            }
-            .onChange(of: alertSheetPresented) {
-                resetState(alertSheetPresented)
-            }
             .alert(isPresented: $alertPresented) {
                 if case .alert(let alert) = actionState {
                     alert

--- a/ScanAndGo/Shopping/Models/Shopper+Checkout.swift
+++ b/ScanAndGo/Shopping/Models/Shopper+Checkout.swift
@@ -26,7 +26,6 @@ extension Shopper {
     func startCheckout() {
         guard let paymentMethod = self.paymentManager.selectedPayment?.method else {
             logger.debug("selectedPayment method is nil")
-            sendAction(.alertSheet(paymentManager))
             return
         }
         

--- a/ScanAndGo/Shopping/Models/Shopper.swift
+++ b/ScanAndGo/Shopping/Models/Shopper.swift
@@ -71,6 +71,15 @@ public final class Shopper: ObservableObject, BarcodeProcessing, Equatable {
     /// A list of payment methods that are restricted for the shopper.
     public var restrictedPayments: [RawPaymentMethod] = []
     
+    /// A list of supported payment methods that the backend provides from the current shopping cart.
+    public var supportedShoppingCartPayments: [RawPaymentMethod]? {
+        cartModel.shoppingCart.supportedPayments
+    }
+    
+    /// A list of supported payment methods of the current project.
+    public var projectPayments: [RawPaymentMethod] {
+        project.availablePaymentMethods.filter({ !restrictedPayments.contains($0) })
+    }
     /// Provides a dynamic member lookup for retrieving payment icons.
     ///
     /// - Parameter member: The member name to lookup.

--- a/ScanAndGo/Shopping/Models/Shopper.swift
+++ b/ScanAndGo/Shopping/Models/Shopper.swift
@@ -127,11 +127,7 @@ public final class Shopper: ObservableObject, BarcodeProcessing, Equatable {
         if case .idle = newState {
             startScanner()
         } else {
-            if case.alertSheet = newState {
-                logger.debug("Don't stop scanner while showing alertSheet")
-            } else {
-                stopScanner()
-            }
+            stopScanner()
         }
     }
     

--- a/ScanAndGo/Shopping/Views/CheckoutView.swift
+++ b/ScanAndGo/Shopping/Views/CheckoutView.swift
@@ -65,9 +65,11 @@ struct CheckoutView: View {
                     }
                 }
                 .bottomSheet(isPresented: $showPaymentSelector) {
-                    PaymentSelectionView(project: model.project) { paymentMethodItem in
-                        if let paymentMethodItem {
-                            model.paymentManager.setSelectedPaymentItem(paymentMethodItem)
+                    PaymentSelectionView(project: model.project,
+                                         availablePayments: model.projectPayments,
+                                         supportedPayments: model.supportedShoppingCartPayments) { paymentItem in
+                        if let paymentItem {
+                            model.paymentManager.setSelectedPaymentItem(paymentItem)
                         }
                         showPaymentSelector = false
                     }

--- a/ScanAndGo/Shopping/Views/CheckoutView.swift
+++ b/ScanAndGo/Shopping/Views/CheckoutView.swift
@@ -20,6 +20,7 @@ struct CheckoutView: View {
     
     @State private var countString: String = ""
     @State private var totalString: String = ""
+    @State private var showPaymentSelector: Bool = false
     
     @State var cancellables = Set<AnyCancellable>()
     
@@ -47,7 +48,7 @@ struct CheckoutView: View {
                 HStack(spacing: 16) {
                     if model.hasValidPayment {
                         PaymentButtonView(model: model, onAction: {
-                            model.sendAction(.alertSheet(model.paymentManager))
+                            showPaymentSelector = true
                         })
                         .frame(width: 88, height: 38)
                         if model.paymentManager.selectedPayment != nil {
@@ -58,12 +59,22 @@ struct CheckoutView: View {
                         }
                     } else {
                         PaymentButtonView(model: model, onAction: {
-                            model.sendAction(.alertSheet(model.paymentManager))
+                            showPaymentSelector = true
                         })
                         .frame(minWidth: 88, maxWidth: .infinity)
                     }
                 }
-            }
+                .bottomSheet(isPresented: $showPaymentSelector) {
+                    PaymentSelectionView(project: model.project) { paymentMethodItem in
+                        if let paymentMethodItem {
+                            print("select payment: \(paymentMethodItem.title)")
+                        } else {
+                            print("select payment: nil")
+                        }
+                        showPaymentSelector = false
+                    }
+                }
+           }
             .padding([.leading, .trailing], 16)
             .padding(.bottom, 10)
             Divider()

--- a/ScanAndGo/Shopping/Views/CheckoutView.swift
+++ b/ScanAndGo/Shopping/Views/CheckoutView.swift
@@ -67,9 +67,7 @@ struct CheckoutView: View {
                 .bottomSheet(isPresented: $showPaymentSelector) {
                     PaymentSelectionView(project: model.project) { paymentMethodItem in
                         if let paymentMethodItem {
-                            print("select payment: \(paymentMethodItem.title)")
-                        } else {
-                            print("select payment: nil")
+                            model.paymentManager.setSelectedPaymentItem(paymentMethodItem)
                         }
                         showPaymentSelector = false
                     }

--- a/ScanAndGo/Shopping/Views/CheckoutView.swift
+++ b/ScanAndGo/Shopping/Views/CheckoutView.swift
@@ -79,6 +79,9 @@ struct CheckoutView: View {
             .padding(.bottom, 10)
             Divider()
         }
+        .onAppear {
+            model.paymentManager.update()
+        }
         .task {
             update()
         }

--- a/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
+++ b/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
@@ -1,0 +1,92 @@
+//
+//  File.swift
+//  Snabble
+//
+//  Created by Uwe Tilemann on 22.10.24.
+//
+
+import SwiftUI
+
+import SnabbleCore
+import SnabbleUI
+import SnabbleAssetProviding
+/*
+    let isAnyActive = actions.contains { $0.active == true && $0.method.offline == false }
+
+     let icon = isAnyActive && !(action.active || action.methodDetail != nil) ? action.icon?.grayscale() : action.icon
+
+ */
+public struct PaymentMethodItemView: View {
+    
+    var item: PaymentMethodItem
+    var isActive: Bool
+    
+    public var body: some View {
+        HStack {
+            if let icon = item.icon {
+                Image(uiImage: icon)
+                    .blendMode(isActive ? .normal : .luminosity)
+                    .opacity(isActive ? 1 : 0.8)
+            }
+            VStack(alignment: .leading) {
+                Text(item.title)
+                    .foregroundStyle(isActive ? .primary : .secondary)
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal)
+    }
+}
+
+public struct PaymentSelectionView: View {
+    var project: Project
+    
+    @State var items: [PaymentMethodItem] = []
+    @State var isAnyActive = false
+    @ScaledMetric var minHeight: CGFloat = 40
+
+    public var body: some View {
+            VStack(spacing: 10) {
+                VStack {
+                    Text(keyed: "Snabble.Shoppingcart.howToPay")
+                        .font(.footnote)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 10)
+                        .padding(.bottom, 5)
+                    VStack(alignment: .leading) {
+                        ForEach(items) { item in
+                            Divider()
+                            PaymentMethodItemView(item: item, isActive: !(isAnyActive && !(item.active || item.methodDetail != nil)))
+                                .frame(height: minHeight)
+                        }
+                    }
+                    .padding(.bottom, 10)
+                }
+                .background(RoundedRectangle(cornerRadius: 15).fill(.regularMaterial))
+                .padding(.horizontal, 10)
+                
+                Button(action: {
+                    
+                }) {
+                    HStack {
+                        Spacer()
+                        Text(keyed: "Snabble.cancel")
+                        Spacer()
+                    }
+                }
+                .padding(.vertical, 18)
+                .background(RoundedRectangle(cornerRadius: 15).fill(.regularMaterial))
+                .padding(.horizontal, 10)
+            }
+
+            .onAppear {
+            items = project.supportedPaymentMethodItems()
+            isAnyActive = items.contains { $0.active == true && $0.method.offline == false }
+        }
+    }
+}

--- a/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
+++ b/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
@@ -87,7 +87,7 @@ public struct PaymentSelectionView: View {
             }
 
             .onAppear {
-            items = project.supportedPaymentMethodItems()
+            items = project.paymentItems()
             isAnyActive = items.contains { $0.active == true && $0.method.offline == false }
         }
     }

--- a/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
+++ b/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
@@ -42,52 +42,66 @@ public struct PaymentMethodItemView: View {
 public struct PaymentSelectionView: View {
     var project: Project
     
+    var availablePayments: [RawPaymentMethod]
+    var supportedPayments: [RawPaymentMethod]?
+    
     let onAction: (PaymentMethodItem?) -> Void
     
     @State var items: [PaymentMethodItem] = []
     @State var isAnyActive = false
     @ScaledMetric var minHeight: CGFloat = 40
     
+    public init(project: Project,
+                availablePayments: [RawPaymentMethod],
+                supportedPayments: [RawPaymentMethod]? = nil,
+               onAction: @escaping (PaymentMethodItem?) -> Void) {
+        self.project = project
+        self.availablePayments = availablePayments
+        self.supportedPayments = supportedPayments
+        self.onAction = onAction
+    }
+    
     public var body: some View {
-            VStack(spacing: 10) {
-                VStack {
-                    Text(keyed: "Snabble.Shoppingcart.howToPay")
-                        .font(.footnote)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.secondary)
-                        .padding(.top, 10)
-                        .padding(.bottom, 5)
-                    VStack(alignment: .leading) {
-                        ForEach(items) { item in
-                            Divider()
-                            PaymentMethodItemView(item: item, isActive: !(isAnyActive && !(item.active || item.methodDetail != nil)))
-                                .frame(height: minHeight)
-                                .onTapGesture {
-                                    onAction(item)
-                                }
-                        }
-                    }
-                    .padding(.bottom, 10)
-                }
-                .background(RoundedRectangle(cornerRadius: 15).fill(.regularMaterial))
-                .padding(.horizontal, 10)
-                
-                Button(action: {
-                    onAction(nil)
-                }) {
-                    HStack {
-                        Spacer()
-                        Text(keyed: "Snabble.cancel")
-                        Spacer()
+        VStack(spacing: 10) {
+            VStack {
+                Text(keyed: "Snabble.Shoppingcart.howToPay")
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 10)
+                    .padding(.bottom, 5)
+                VStack(alignment: .leading) {
+                    ForEach(items) { item in
+                        Divider()
+                        PaymentMethodItemView(item: item, isActive: !(isAnyActive && !(item.active || item.methodDetail != nil)))
+                            .frame(height: minHeight)
+                            .onTapGesture {
+                                onAction(item)
+                            }
                     }
                 }
-                .padding(.vertical, 18)
-                .background(RoundedRectangle(cornerRadius: 15).fill(.regularMaterial))
-                .padding(.horizontal, 10)
+                .padding(.bottom, 10)
             }
-
-            .onAppear {
-            items = project.paymentItems()
+            .background(RoundedRectangle(cornerRadius: 15).fill(.regularMaterial))
+            .padding(.horizontal, 10)
+            
+            Button(action: {
+                onAction(nil)
+            }) {
+                HStack {
+                    Spacer()
+                    Text(keyed: "Snabble.cancel")
+                    Spacer()
+                }
+            }
+            .padding(.vertical, 18)
+            .background(RoundedRectangle(cornerRadius: 15).fill(.regularMaterial))
+            .padding(.horizontal, 10)
+        }
+        
+        .onAppear {
+            items = project.paymentItems(for: supportedPayments)
+                .filter({ availablePayments.contains($0.method) })
             isAnyActive = items.contains { $0.active == true && $0.method.offline == false }
         }
     }

--- a/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
+++ b/ScanAndGo/Shopping/Views/PaymentSelectionView.swift
@@ -10,12 +10,7 @@ import SwiftUI
 import SnabbleCore
 import SnabbleUI
 import SnabbleAssetProviding
-/*
-    let isAnyActive = actions.contains { $0.active == true && $0.method.offline == false }
 
-     let icon = isAnyActive && !(action.active || action.methodDetail != nil) ? action.icon?.grayscale() : action.icon
-
- */
 public struct PaymentMethodItemView: View {
     
     var item: PaymentMethodItem
@@ -37,7 +32,9 @@ public struct PaymentMethodItemView: View {
                         .foregroundStyle(.secondary)
                 }
             }
+            Spacer()
         }
+        .contentShape(Rectangle())
         .padding(.horizontal)
     }
 }
@@ -45,10 +42,12 @@ public struct PaymentMethodItemView: View {
 public struct PaymentSelectionView: View {
     var project: Project
     
+    let onAction: (PaymentMethodItem?) -> Void
+    
     @State var items: [PaymentMethodItem] = []
     @State var isAnyActive = false
     @ScaledMetric var minHeight: CGFloat = 40
-
+    
     public var body: some View {
             VStack(spacing: 10) {
                 VStack {
@@ -63,6 +62,9 @@ public struct PaymentSelectionView: View {
                             Divider()
                             PaymentMethodItemView(item: item, isActive: !(isAnyActive && !(item.active || item.methodDetail != nil)))
                                 .frame(height: minHeight)
+                                .onTapGesture {
+                                    onAction(item)
+                                }
                         }
                     }
                     .padding(.bottom, 10)
@@ -71,7 +73,7 @@ public struct PaymentSelectionView: View {
                 .padding(.horizontal, 10)
                 
                 Button(action: {
-                    
+                    onAction(nil)
                 }) {
                     HStack {
                         Spacer()

--- a/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
+++ b/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
@@ -142,8 +142,7 @@ struct ScannerCartItemView: View {
     @ObservedObject var model: Shopper
     
     let scannedItem: BarcodeManager.ScannedItem
-    let onDismiss: () -> Void
-    let onAdd: (_ cartItem: CartItem) -> Void
+    let onDismiss: (_ cartItem: CartItem?) -> Void
     let alreadyInCart: Bool
     
     @State private var cartItem: CartItem
@@ -156,12 +155,10 @@ struct ScannerCartItemView: View {
     
     init(model: Shopper,
          scannedItem: BarcodeManager.ScannedItem,
-         onDismiss: @escaping () -> Void,
-         onAdd: @escaping (_ cartItem: CartItem) -> Void
+         onDismiss: @escaping (_ cartItem: CartItem?) -> Void
     ) {
         self.model = model
         self.scannedItem = scannedItem
-        self.onAdd = onAdd
         self.onDismiss = onDismiss
         
         let result = model.cartItem(for: scannedItem)
@@ -181,7 +178,7 @@ struct ScannerCartItemView: View {
         VStack {
             VStack(spacing: 6) {
                 Button(action: {
-                    onDismiss()
+                    onDismiss(nil)
                 }) {
                     SwiftUI.Image(systemName: "xmark")
                         .font(.title2)
@@ -218,7 +215,7 @@ struct ScannerCartItemView: View {
                 let title = alreadyInCart ? Asset.localizedString(forKey: "Snabble.Scanner.updateCart") : Asset.localizedString(forKey: "Snabble.Scanner.addToCart")
                 
                 PrimaryButtonView(title: title, disabled: $disableCheckout, onAction: {
-                    onAdd(cartItem)
+                    onDismiss(cartItem)
                 })
                 .padding()
             }
@@ -247,7 +244,7 @@ struct ScannerCartItemView: View {
 struct ScannedItemEditorView: View {
     @SwiftUI.Environment(\.keyboardHeight) var keyboardHeight
     @ObservedObject var model: Shopper
-    var onDismiss: () -> Void
+    var onDismiss: (CartItem?) -> Void
     
     var body: some View {
         VStack {
@@ -256,17 +253,9 @@ struct ScannedItemEditorView: View {
                 ScannerCartItemView(
                     model: model,
                     scannedItem: scannedItem,
-                    onDismiss: onDismiss,
-                    onAdd: { cartItem in
-                        updateCartItem(cartItem)
-                    })
+                    onDismiss: onDismiss)
             }
         }
         .padding(.bottom, (keyboardHeight > 0 ? 20 : 150))
-    }
-    
-    private func updateCartItem(_ cartItem: CartItem) {
-        model.updateCartItem(cartItem)
-        onDismiss()
     }
 }

--- a/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
+++ b/ScanAndGo/Shopping/Views/ScannedItemEditorView.swift
@@ -262,7 +262,7 @@ struct ScannedItemEditorView: View {
                     })
             }
         }
-        .padding(.bottom, (keyboardHeight > 0 ? keyboardHeight + 80 : 150))
+        .padding(.bottom, (keyboardHeight > 0 ? 20 : 150))
     }
     
     private func updateCartItem(_ cartItem: CartItem) {

--- a/ScanAndGo/Shopping/Views/ShopperNavigation.swift
+++ b/ScanAndGo/Shopping/Views/ShopperNavigation.swift
@@ -47,7 +47,7 @@ extension Shopper {
     @ViewBuilder
     public func navigationDestination(isPresented: Binding<Bool>) -> some View {
         if let controller {
-            ContainerView(viewController: controller, isPresented: isPresented)
+            ContainerView(viewController: controller)
                 .navigationTitle(controller.navigationItem.title ?? "Navigation")
         } else {
             InvalidNavigationView(isPresented: isPresented)

--- a/ScanAndGo/Shopping/Views/ShopperView.swift
+++ b/ScanAndGo/Shopping/Views/ShopperView.swift
@@ -38,8 +38,13 @@ public struct ShopperView: View {
                 Text(model.errorMessage ?? "No errorMessage! This should not happen! 😳")
             }
             .windowDialog(isPresented: $showEditor) {
-                ScannedItemEditorView(model: model) {
-                    showEditor = false
+                ScannedItemEditorView(model: model) { cartItem in
+                    showEditor.toggle()
+                    if let cartItem {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                            model.updateCartItem(cartItem)
+                        }
+                    }
                 }
             }
             .keyboardHeightEnvironmentValue()

--- a/ScanAndGo/Utilities/ContainerView.swift
+++ b/ScanAndGo/Utilities/ContainerView.swift
@@ -24,7 +24,7 @@ public struct ContainerView: UIViewControllerRepresentable {
     public func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
     }
-    
+
     // swiftlint:disable:next no_empty_block
     public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
     
@@ -34,11 +34,7 @@ public struct ContainerView: UIViewControllerRepresentable {
         init(parent: ContainerView) {
             self.parent = parent
         }
-        
-        deinit {
-            parent.isPresented = false
-        }
-        
+                
         var viewController: UIViewController {
             parent.viewController
         }

--- a/UI/Sources/ShoppingCart/Models/PaymentMethodManager.swift
+++ b/UI/Sources/ShoppingCart/Models/PaymentMethodManager.swift
@@ -223,7 +223,7 @@ struct PaymentMethodAction: PaymentPovider {
 extension Project {
     func paymentActions(for shoppingCart: ShoppingCart? = nil) -> [PaymentMethodAction] {
         // combine all payment methods of all projects
-        let items = paymentItems(for: shoppingCart?.paymentMethods?.map { $0.method })
+        let items = paymentItems(for: shoppingCart?.supportedPayments)
         
         let actions = items.map { item in
             let title = Self.attributedString(

--- a/UI/Sources/ShoppingCart/Models/PaymentMethodManager.swift
+++ b/UI/Sources/ShoppingCart/Models/PaymentMethodManager.swift
@@ -166,21 +166,11 @@ extension PaymentMethodItem {
     }
 }
 
-extension Snabble {
-    public func allAvailablePaymentMethods() -> [RawPaymentMethod] {
-        projects
-            .flatMap(\.paymentMethods)
-            .filter(\.isAvailable)
-    }
-}
-
 extension Project {
     public var orderedPaymentMethods: [RawPaymentMethod] {
-        let allAppMethods = Snabble.shared.allAvailablePaymentMethods()
         
         // and get them in the desired display order
         return RawPaymentMethod.orderedMethods
-            .filter { allAppMethods.contains($0) }
             .filter { paymentMethods.available.contains($0) }
     }
     

--- a/UI/Sources/ShoppingCart/Models/PaymentMethodManager.swift
+++ b/UI/Sources/ShoppingCart/Models/PaymentMethodManager.swift
@@ -358,7 +358,12 @@ public final class PaymentMethodManager: ObservableObject {
             self.setSelectedPayment(self.selectedPayment?.method, detail: self.selectedPayment?.detail)
         }
     }
-
+    
+    public func update() {
+        updateAvailablePaymentMethods()
+        updateSelectionVisibility()
+    }
+    
     private func setSelectedPayment(_ method: RawPaymentMethod?, detail: PaymentMethodDetail?) {
         if let detail {
             self.selectedPayment = Payment(detail: detail)

--- a/UI/Sources/ShoppingCart/Models/ShoppingCartViewModel.swift
+++ b/UI/Sources/ShoppingCart/Models/ShoppingCartViewModel.swift
@@ -25,7 +25,7 @@ open class ShoppingCartViewModel: ObservableObject, Swift.Identifiable, Equatabl
         PriceFormatter(SnabbleCI.project)
     }
     
-    let shoppingCart: ShoppingCart
+    public let shoppingCart: ShoppingCart
     
     public weak var shoppingCartDelegate: ShoppingCartDelegate?
     


### PR DESCRIPTION
- Added `BottomSheet` view modifier
- Added `public func setSelectedPaymentItem(_:)` to PaymentMethodManager
- Remove `alertSheet` from ActionState