### PR TITLE
[NETWORK] Add Order Endpoints

### DIFF
--- a/Network/Sources/Endpoint.swift
+++ b/Network/Sources/Endpoint.swift
@@ -32,14 +32,13 @@ public struct Endpoint<Response> {
 
     var token: Token?
     var headerFields: [String: String] = [:]
+    var domain: Domain = .production
 
     public init(path: String, method: HTTPMethod, parse: @escaping (Data) throws -> Response) {
         self.path = path
         self.method = method
         self.parse = parse
     }
-
-    var domain: Domain = .production
 
     enum Error: Swift.Error {
         case invalidRequestError(String)

--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-
-
 extension Endpoints {
     public enum Order {
         private static var jsonDecoder: JSONDecoder {

--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -7,8 +7,21 @@
 
 import Foundation
 
+
+
 extension Endpoints {
     public enum Order {
+        private static var jsonDecoder: JSONDecoder {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"
+            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+            dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+            
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .formatted(dateFormatter)
+            return decoder
+        }
+        
         private static func path(forAppUserId appUserId: String) -> String {
             "/apps/users/\(appUserId)/orders"
         }
@@ -18,7 +31,7 @@ extension Endpoints {
                 path: path(forAppUserId: appUserId),
                 method: .get(nil),
                 parse: { data in
-                    try Endpoints.jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data).orders
+                    try jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data).orders
                 }
             )
         }
@@ -28,7 +41,7 @@ extension Endpoints {
                 path: path(forAppUserId: appUserId),
                 method: .get(nil),
                 parse: { data in
-                    try Endpoints.jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data)
+                    try jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data)
                         .orders
                         .filter { $0.projectId == projectId }
                 }
@@ -40,7 +53,7 @@ extension Endpoints {
                 path: path(forAppUserId: appUserId),
                 method: .get(nil),
                 parse: { data in
-                    try Endpoints.jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data)
+                    try jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data)
                         .orders
                         .filter { $0.projectId == projectId }
                         .filter { $0.shopId == shopId }

--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -1,0 +1,57 @@
+//
+//  ReceiptsEndpoint.swift
+//  Snabble
+//
+//  Created by Andreas Osberghaus on 2024-11-04.
+//
+
+import Foundation
+
+extension Endpoints {
+    public enum Order {
+        public static func get(forAppUserId appUserId: String) -> Endpoint<[SnabbleNetwork.Order]> {
+            return .init(
+                path: "/apps/users/\(appUserId)/orders",
+                method: .get(nil),
+                parse: { data in
+                    try Endpoints.jsonDecoder.decode([SnabbleNetwork.Order].self, from: data)
+                }
+            )
+        }
+        
+        public static func get(forAppUserId appUserId: String, filteredByProjectId projectId: String) -> Endpoint<[SnabbleNetwork.Order]> {
+            return .init(
+                path: "/apps/users/\(appUserId)/orders",
+                method: .get(nil),
+                parse: { data in
+                    try Endpoints.jsonDecoder.decode([SnabbleNetwork.Order].self, from: data)
+                        .filter { $0.projectId == projectId }
+                }
+            )
+        }
+        
+        public static func get(forAppUserId appUserId: String, filteredByProjectId projectId: String, andShopId shopId: String) -> Endpoint<[SnabbleNetwork.Order]> {
+            return .init(
+                path: "/apps/users/\(appUserId)/orders",
+                method: .get(nil),
+                parse: { data in
+                    try Endpoints.jsonDecoder.decode([SnabbleNetwork.Order].self, from: data)
+                        .filter { $0.projectId == projectId }
+                        .filter { $0.shopId == shopId }
+                }
+            )
+        }
+        
+        enum Receipts {
+            public static func receipt(forOrder order: SnabbleNetwork.Order) -> Endpoint<URL> {                
+                return .init(
+                    path: order.receiptPath,
+                    method: .get(nil),
+                    parse: {
+                        try order.saveReceipt(forData: $0)
+                    }
+                )
+            }
+        }
+    }
+}

--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -61,7 +61,7 @@ extension Endpoints {
             )
         }
         
-        enum Receipts {
+        public enum Receipts {
             public static func receipt(forOrder order: SnabbleNetwork.Order) -> Endpoint<URL> {                
                 return .init(
                     path: order.receiptPath,

--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -9,22 +9,27 @@ import Foundation
 
 extension Endpoints {
     public enum Order {
+        private static func path(forAppUserId appUserId: String) -> String {
+            "/apps/users/\(appUserId)/orders"
+        }
+        
         public static func get(forAppUserId appUserId: String) -> Endpoint<[SnabbleNetwork.Order]> {
             return .init(
-                path: "/apps/users/\(appUserId)/orders",
+                path: path(forAppUserId: appUserId),
                 method: .get(nil),
                 parse: { data in
-                    try Endpoints.jsonDecoder.decode([SnabbleNetwork.Order].self, from: data)
+                    try Endpoints.jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data).orders
                 }
             )
         }
         
         public static func get(forAppUserId appUserId: String, filteredByProjectId projectId: String) -> Endpoint<[SnabbleNetwork.Order]> {
             return .init(
-                path: "/apps/users/\(appUserId)/orders",
+                path: path(forAppUserId: appUserId),
                 method: .get(nil),
                 parse: { data in
-                    try Endpoints.jsonDecoder.decode([SnabbleNetwork.Order].self, from: data)
+                    try Endpoints.jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data)
+                        .orders
                         .filter { $0.projectId == projectId }
                 }
             )
@@ -32,10 +37,11 @@ extension Endpoints {
         
         public static func get(forAppUserId appUserId: String, filteredByProjectId projectId: String, andShopId shopId: String) -> Endpoint<[SnabbleNetwork.Order]> {
             return .init(
-                path: "/apps/users/\(appUserId)/orders",
+                path: path(forAppUserId: appUserId),
                 method: .get(nil),
                 parse: { data in
-                    try Endpoints.jsonDecoder.decode([SnabbleNetwork.Order].self, from: data)
+                    try Endpoints.jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data)
+                        .orders
                         .filter { $0.projectId == projectId }
                         .filter { $0.shopId == shopId }
                 }

--- a/Network/Sources/Models/Order.swift
+++ b/Network/Sources/Models/Order.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+struct Orders: Codable {
+    let orders: [Order]
+}
+
 public struct Order: Codable {
     public let id: String
     public let date: Date

--- a/Network/Sources/Models/Order.swift
+++ b/Network/Sources/Models/Order.swift
@@ -1,0 +1,73 @@
+//
+//  Order.swift
+//  Snabble
+//
+//  Created by Andreas Osberghaus on 2024-11-04.
+//
+
+import Foundation
+
+public struct Order: Codable {
+    public let id: String
+    public let date: Date
+    
+    public let projectId: String
+    
+    public let shopId: String
+    public let shopName: String
+    
+    public let price: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case projectId = "project"
+        case id, date, shopName, price
+        case shopId = "shopID"
+    }
+    
+    var receiptPath: String {
+        "/\(projectId)/orders/id/\(id)/receipt"
+    }
+    
+    var receiptFileName: String {
+        "snabble-order-\(id).pdf"
+    }
+    
+    private static var fileManager: FileManager {
+        .default
+    }
+    
+    func saveReceipt(forData data: Data) throws -> URL {
+        let documentsDirectory = try Self.fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        let fileURL = documentsDirectory.appendingPathComponent(receiptFileName)
+        try data.write(to: fileURL)
+        return fileURL
+    }
+    
+    public func receiptURL() throws -> URL {
+        let documentDirectory = try Self.fileManager.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return documentDirectory.appendingPathComponent(receiptFileName)
+    }
+    
+    public var isReceiptDownloaded: Bool {
+        guard let receiptURL = try? receiptURL() else {
+            return false
+        }
+        return Self.fileManager.fileExists(atPath: receiptURL.path)
+    }
+    
+    public static func deleteLocalReceipts() throws {
+        let cacheDir = try Self.fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        let files = try Self.fileManager.contentsOfDirectory(atPath: cacheDir.path)
+        for file in files {
+            if file.hasPrefix("snabble-order-") && file.hasSuffix(".pdf") {
+                let fullPath = cacheDir.appendingPathComponent(file)
+                try Self.fileManager.removeItem(atPath: fullPath.path)
+            }
+        }
+    }
+}

--- a/Network/Sources/Models/Order.swift
+++ b/Network/Sources/Models/Order.swift
@@ -9,6 +9,16 @@ import Foundation
 
 struct Orders: Codable {
     let orders: [Order]
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        orders = try container.decode([Order].self, forKey: .orders).filter {
+            guard let href = $0.links.receipt?.href, !href.isEmpty else {
+                return false
+            }
+            return true
+        }
+    }
 }
 
 public struct Order: Codable {
@@ -22,20 +32,21 @@ public struct Order: Codable {
     
     public let price: Int
     
-    public init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.projectId = try container.decode(String.self, forKey: .projectId)
-        self.id = try container.decode(String.self, forKey: .id)
-        self.date = try container.decode(Date.self, forKey: .date)
-        self.shopName = try container.decode(String.self, forKey: .shopName)
-        self.price = try container.decode(Int.self, forKey: .price)
-        self.shopId = try container.decode(String.self, forKey: .shopId)
+    let links: Links
+    
+    struct Links: Codable {
+        let receipt: Link?
+        
+        struct Link: Codable {
+            let href: String
+        }
     }
     
     enum CodingKeys: String, CodingKey {
         case projectId = "project"
         case id, date, shopName, price
         case shopId = "shopID"
+        case links
     }
     
     var receiptPath: String {

--- a/Network/Sources/Models/Order.swift
+++ b/Network/Sources/Models/Order.swift
@@ -22,6 +22,16 @@ public struct Order: Codable {
     
     public let price: Int
     
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.projectId = try container.decode(String.self, forKey: .projectId)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.date = try container.decode(Date.self, forKey: .date)
+        self.shopName = try container.decode(String.self, forKey: .shopName)
+        self.price = try container.decode(Int.self, forKey: .price)
+        self.shopId = try container.decode(String.self, forKey: .shopId)
+    }
+    
     enum CodingKeys: String, CodingKey {
         case projectId = "project"
         case id, date, shopName, price

--- a/Network/Sources/URLSession+Endpoint.swift
+++ b/Network/Sources/URLSession+Endpoint.swift
@@ -54,3 +54,21 @@ extension URLSession {
             .eraseToAnyPublisher()
     }
 }
+
+extension URLSession {
+    func downloadTaskPublisher(for url: URL) -> AnyPublisher<URL, URLError> {
+        Future<URL, URLError> { promise in
+            let task = self.downloadTask(with: url) { location, _, error in
+                if let error = error as? URLError {
+                    promise(.failure(error))
+                } else if let location = location {
+                    promise(.success(location))
+                } else {
+                    promise(.failure(URLError(.unknown)))
+                }
+            }
+            task.resume()
+        }
+        .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
1. implement order endpoints to load completed orders
   * receipt link cannot be empty
   * only completed orders are accessible
2. implement receipt download with a dataTask instead of downloadTask
   * the pdfs are very small which reduces the risk of a memory overload
   * if it happens we have to refactor to a downloadTask for specific endpoints