### PR TITLE
Remove Receipt Handling Logic from SDK #APPS-1976

### DIFF
--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -35,16 +35,16 @@ extension Endpoints {
         }
         
         public enum Receipts {
-            public static func receipt(forOrder order: SnabbleNetwork.Order) -> Endpoint<URL> {                
+            public static func receipt(forOrder order: SnabbleNetwork.Order) -> Endpoint<Data> {
                 receipt(forTransactionId: order.id, withProjectId: order.projectId)
             }
             
-            public static func receipt(forTransactionId transactionId: String, withProjectId projectId: String) -> Endpoint<URL> {
+            public static func receipt(forTransactionId transactionId: String, withProjectId projectId: String) -> Endpoint<Data> {
                 return .init(
                     path: "/\(projectId)/orders/id/\(transactionId)/receipt",
                     method: .get(nil),
-                    parse: {
-                        try SnabbleNetwork.Order.saveReceipt(forData: $0, withID: transactionId)
+                    parse: { data in
+                        data
                     }
                 )
             }

--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -36,11 +36,15 @@ extension Endpoints {
         
         public enum Receipts {
             public static func receipt(forOrder order: SnabbleNetwork.Order) -> Endpoint<URL> {                
+                receipt(forTransactionId: order.id, withProjectId: order.projectId)
+            }
+            
+            public static func receipt(forTransactionId transactionId: String, withProjectId projectId: String) -> Endpoint<URL> {
                 return .init(
-                    path: order.receiptPath,
+                    path: "/\(projectId)/orders/id/\(transactionId)/receipt",
                     method: .get(nil),
                     parse: {
-                        try order.saveReceipt(forData: $0)
+                        try SnabbleNetwork.Order.saveReceipt(forData: $0, withID: transactionId)
                     }
                 )
             }

--- a/Network/Sources/Models/Order.swift
+++ b/Network/Sources/Models/Order.swift
@@ -41,74 +41,11 @@ public struct Order: Decodable {
         case isSuccessful
     }
     
-    var receiptFileName: String {
-        Self.receiptFileName(forId: id)
-    }
-    
-    static func receiptFileName(forId id: String) -> String {
-        "snabble-order-\(id).pdf"
-    }
-    
-    private static var fileManager: FileManager {
-        .default
-    }
-    
     public var hasReceipt: Bool {
         guard let href = links.receipt?.href, !href.isEmpty else {
             return false
         }
         return true
-    }
-    
-    static func saveReceipt(forData data: Data, withID id: String) throws -> URL {
-        let documentsDirectory = try Self.fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-        let fileURL = documentsDirectory.appendingPathComponent(receiptFileName(forId: id))
-        try data.write(to: fileURL)
-        return fileURL
-    }
-    
-    public func receiptURL() throws -> URL {
-        try Self.receiptURL(forID: id)
-    }
-    
-    public static func receiptURL(forID id: String) throws -> URL {
-        let documentDirectory = try Self.fileManager.url(
-            for: .documentDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        return documentDirectory.appendingPathComponent(receiptFileName(forId: id))
-    }
-    
-    public var isReceiptDownloaded: Bool {
-        Self.isReceiptDownloaded(forID: id)
-    }
-    
-    public static func isReceiptDownloaded(forID id: String) -> Bool {
-        guard let receiptURL = try? receiptURL(forID: id) else {
-            return false
-        }
-        return Self.fileManager.fileExists(atPath: receiptURL.path)
-    }
-    
-    public func deleteLocalReceipt() throws {
-        try Self.deleteLocalReceipt(forID: id)
-    }
-    
-    public static func deleteLocalReceipt(forID id: String) throws {
-        try Self.fileManager.removeItem(at: try receiptURL(forID: id))
-    }
-    
-    public static func deleteLocalReceipts() throws {
-        let cacheDir = try Self.fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-        let files = try Self.fileManager.contentsOfDirectory(atPath: cacheDir.path)
-        for file in files {
-            if file.hasPrefix("snabble-order-") && file.hasSuffix(".pdf") {
-                let fullPath = cacheDir.appendingPathComponent(file)
-                try Self.fileManager.removeItem(atPath: fullPath.path)
-            }
-        }
     }
 }
 

--- a/Network/Sources/Models/Order.swift
+++ b/Network/Sources/Models/Order.swift
@@ -41,11 +41,11 @@ public struct Order: Decodable {
         case isSuccessful
     }
     
-    var receiptPath: String {
-        "/\(projectId)/orders/id/\(id)/receipt"
+    var receiptFileName: String {
+        Self.receiptFileName(forId: id)
     }
     
-    var receiptFileName: String {
+    static func receiptFileName(forId id: String) -> String {
         "snabble-order-\(id).pdf"
     }
     
@@ -60,32 +60,44 @@ public struct Order: Decodable {
         return true
     }
     
-    func saveReceipt(forData data: Data) throws -> URL {
+    static func saveReceipt(forData data: Data, withID id: String) throws -> URL {
         let documentsDirectory = try Self.fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-        let fileURL = documentsDirectory.appendingPathComponent(receiptFileName)
+        let fileURL = documentsDirectory.appendingPathComponent(receiptFileName(forId: id))
         try data.write(to: fileURL)
         return fileURL
     }
     
     public func receiptURL() throws -> URL {
+        try Self.receiptURL(forID: id)
+    }
+    
+    public static func receiptURL(forID id: String) throws -> URL {
         let documentDirectory = try Self.fileManager.url(
             for: .documentDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
         )
-        return documentDirectory.appendingPathComponent(receiptFileName)
+        return documentDirectory.appendingPathComponent(receiptFileName(forId: id))
     }
     
     public var isReceiptDownloaded: Bool {
-        guard let receiptURL = try? receiptURL() else {
+        Self.isReceiptDownloaded(forID: id)
+    }
+    
+    public static func isReceiptDownloaded(forID id: String) -> Bool {
+        guard let receiptURL = try? receiptURL(forID: id) else {
             return false
         }
         return Self.fileManager.fileExists(atPath: receiptURL.path)
     }
     
     public func deleteLocalReceipt() throws {
-        try Self.fileManager.removeItem(at: receiptURL())
+        try Self.deleteLocalReceipt(forID: id)
+    }
+    
+    public static func deleteLocalReceipt(forID id: String) throws {
+        try Self.fileManager.removeItem(at: try receiptURL(forID: id))
     }
     
     public static func deleteLocalReceipts() throws {


### PR DESCRIPTION
* Removes receipt saving, lookup for receipts
* Adds the ability to load a receipt with primitive data types