### PR TITLE
[NETWORK] Remove `appUserId` in path for orders #APPS-2003

### DIFF
--- a/Network/Sources/Endpoints/OrderEndpoint.swift
+++ b/Network/Sources/Endpoints/OrderEndpoint.swift
@@ -20,13 +20,9 @@ extension Endpoints {
             return decoder
         }
         
-        private static func path(forAppUserId appUserId: String) -> String {
-            "/apps/users/\(appUserId)/orders"
-        }
-        
-        public static func get(forAppUserId appUserId: String) -> Endpoint<[SnabbleNetwork.Order]> {
+        public static func get() -> Endpoint<[SnabbleNetwork.Order]> {
             return .init(
-                path: path(forAppUserId: appUserId),
+                path: "/apps/users/me/orders",
                 method: .get(nil),
                 parse: { data in
                     try jsonDecoder.decode(SnabbleNetwork.Orders.self, from: data).orders


### PR DESCRIPTION
Replace `apps/users/${appUserId}/orders` with `apps/users/me/orders`.