### PR TITLE
[ScanAndGo] Fix scanner is displayed with a delay #APPS-1955

### DIFF
--- a/ScanAndGo/Shopping/Models/Shopper.swift
+++ b/ScanAndGo/Shopping/Models/Shopper.swift
@@ -216,7 +216,7 @@ public final class Shopper: ObservableObject, BarcodeProcessing, Equatable {
     }
     /// Indicates whether the scanner is ready to scan.
     public var readyToScan: Bool {
-        scanningActivated && !scanningPaused
+        scanningActivated && !scanningPaused && barcodeManager.barcodeDetector.state != .idle
     }
     
     /// Starts the barcode scanner.

--- a/ScanAndGo/Shopping/Views/ShopperView.swift
+++ b/ScanAndGo/Shopping/Views/ShopperView.swift
@@ -63,6 +63,11 @@ public struct ShopperView: View {
             .onDisappear {
                 model.scanningActivated = false
             }
+            .onReceive(model.barcodeManager.barcodeDetector.$state) { state in
+                if state == .ready, model.scanningActivated && !model.scanningPaused {
+                    model.startScanner()
+                }
+            }
             .onReceive(model.$errorMessage) { message in
                 if message != nil {
                     model.startScanner()


### PR DESCRIPTION
### Changes

- Update Shopper `public var readyToScan: Bool` add check `barcodeManager.barcodeDetector.state != .idle`
- Add ShopperView start scanner if `barcodeDetector.state == .ready` and not paused.

https://snabble.atlassian.net/browse/APPS-1955