### PR TITLE
Full Brightness when Exit Code is shown #APPS-876

### DIFF
--- a/UI/Sources/Checkout/CheckoutStep.swift
+++ b/UI/Sources/Checkout/CheckoutStep.swift
@@ -22,6 +22,7 @@ struct CheckoutStep {
     let actionTitle: String?
     let image: UIImage?
     let userInfo: [String: Any]?
+    let fullBrightness: Bool
     
     var kind: Kind {
         if status == nil, detailText == nil, image == nil {
@@ -59,6 +60,7 @@ extension CheckoutStep {
         detailText = nil
         image = nil
         userInfo = nil
+        fullBrightness = false
     }
 }
 
@@ -81,6 +83,7 @@ extension CheckoutStep {
         text = Asset.localizedString(forKey: "Snabble.PaymentStatus.Payment.title")
         image = nil
         userInfo = nil
+        fullBrightness = false
     }
 }
 
@@ -92,7 +95,7 @@ extension CheckoutStep {
         detailText = fulfillment.detailText(for: status!)
         actionTitle = nil
         userInfo = nil
-
+        fullBrightness = false
     }
 
     init(exitToken: ExitToken, paymentState: PaymentState) {
@@ -102,7 +105,7 @@ extension CheckoutStep {
         detailText = image != nil ? Asset.localizedString(forKey: "Snabble.PaymentStatus.ExitCode.openExitGateTimed") : nil
         actionTitle = nil
         userInfo = nil
-
+        fullBrightness = true
     }
 
     init(receiptLink: Link, paymentState: PaymentState) {
@@ -112,6 +115,7 @@ extension CheckoutStep {
         detailText = nil
         actionTitle = nil
         userInfo = ["receiptLink": receiptLink]
+        fullBrightness = false
     }
 
     init(originCandidate: OriginCandidate, savedIbans: Set<String>) {
@@ -126,6 +130,7 @@ extension CheckoutStep {
         image = nil
         detailText = nil
         userInfo = nil
+        fullBrightness = false
     }
 }
 

--- a/UI/Sources/Checkout/CheckoutStepView.swift
+++ b/UI/Sources/Checkout/CheckoutStepView.swift
@@ -13,6 +13,7 @@ protocol CheckoutStepViewModel {
     var actionTitle: String? { get }
     var image: UIImage? { get }
     var userInfo: [String: Any]? { get }
+    var fullBrightness: Bool { get }
 }
 
 struct CheckoutStepView: View {
@@ -47,6 +48,10 @@ struct CheckoutStepView: View {
                         Text(action)
                     }
                 }
+            }
+        }.task {
+            if model.fullBrightness {
+                UIScreen.main.setTemporaryBrightness(to: 1.0)
             }
         }
     }

--- a/UI/Sources/Checkout/CheckoutStepsViewController.swift
+++ b/UI/Sources/Checkout/CheckoutStepsViewController.swift
@@ -126,6 +126,9 @@ struct CheckoutView: View {
             .padding([.leading, .trailing], 20)
             .shadow(radius: 8, x: 0, y: 4)
         }
+        .onDisappear {
+            UIScreen.main.resetBrightness()
+        }
     }
     
     var body: some View {

--- a/UI/Sources/Utilities/ExitToken+Image.swift
+++ b/UI/Sources/Utilities/ExitToken+Image.swift
@@ -16,7 +16,7 @@ public extension ExitToken {
         }
         switch format {
         case .qr:
-            return QRCode.generate(for: value, scale: 4)
+            return QRCode.generate(for: value, scale: 6)
         case .code128:
             return Code128.generate(for: value, scale: 2)
         case .unknown, .ean13, .ean8, .itf14, .code39, .dataMatrix, .pdf417:

--- a/UI/Sources/Utilities/UIScreen+Brightness.swift
+++ b/UI/Sources/Utilities/UIScreen+Brightness.swift
@@ -1,0 +1,27 @@
+//
+//  UIScreen+Brightness.swift
+//  Snabble
+//
+//  Created by Andreas Osberghaus on 2025-01-08.
+//
+import UIKit
+
+extension UIScreen {
+    private static var previousBrightness: CGFloat?
+    
+    // Set the screen brightness temporarily
+    func setTemporaryBrightness(to value: CGFloat) {
+        if UIScreen.previousBrightness == nil {
+            UIScreen.previousBrightness = self.brightness
+        }
+        self.brightness = value
+    }
+    
+    // Reset the screen brightness to the previous value
+    func resetBrightness() {
+        if let previousBrightness = UIScreen.previousBrightness {
+            self.brightness = previousBrightness
+            UIScreen.previousBrightness = nil
+        }
+    }
+}

--- a/UI/Sources/Utilities/UIScreen+Brightness.swift
+++ b/UI/Sources/Utilities/UIScreen+Brightness.swift
@@ -6,7 +6,7 @@
 //
 import UIKit
 
-extension UIScreen {
+public extension UIScreen {
     private static var previousBrightness: CGFloat?
     
     // Set the screen brightness temporarily


### PR DESCRIPTION
Der Exit-Code soll mit voller Helligkeit angezeigt werden.

https://snabble.atlassian.net/browse/APPS-876

### Changes
* Eine Erweiterung von `UIScreen` in `UIScreen+Brightness.swift` implementiert um eine temporäre Helligkeit zu setzen und zurückzusetzen.
* Verwendung der neuen Erweiterung in CheckoutSteps Feature.

### How to test
* Einen Einkauf bei Aldi auf Testing abschließen, dann wird ein Exit-Code angezeigt.