### PR TITLE
Remove applicationData for payone apple pay payment #APPS-1285

### DIFF
--- a/UI/Sources/Payment/ApplePay/ApplePayCheckoutViewController.swift
+++ b/UI/Sources/Payment/ApplePay/ApplePayCheckoutViewController.swift
@@ -73,8 +73,9 @@ final class ApplePayCheckoutViewController: UIViewController {
             descriptor.id == .applePay && descriptor.providerName == .payone
         }) {
             paymentRequest.requiredBillingContactFields = [.name, .postalAddress]
+        } else {
+            paymentRequest.applicationData = process.id.data(using: .utf8)
         }
-        paymentRequest.applicationData = process.id.data(using: .utf8)
         paymentRequest.merchantIdentifier = merchantId
         paymentRequest.countryCode = countryCode
         paymentRequest.currencyCode = process.currency


### PR DESCRIPTION
PayOne bietet keine Möglichkeit die `applicationData` anzunehmen, daher müssen wir sie beim `PKPaymentRequest` entfernen, ansonsten kann PayOne die Signatur nicht verifizieren und damit kein Payment durchführen.

@J-Rocke fragt bei PayOne klärt mit Payone ob eine Anpassung vorgenommen werden sollte.

In der Zwischenzeit werden wir die Information nicht mitsenden, damit die Zahlungen funktionieren.

