### PR TITLE
Warenkorb-Logik für 0€-Einkäufe #APPS-1939

### DIFF
--- a/ScanAndGo/Shopping/Views/CheckoutView.swift
+++ b/ScanAndGo/Shopping/Views/CheckoutView.swift
@@ -53,7 +53,7 @@ struct CheckoutView: View {
                         })
                         .frame(width: 88, height: 38)
                         if model.paymentManager.selectedPayment != nil {
-                            PrimaryButtonView(title: Asset.localizedString(forKey: "Snabble.Shoppingcart.BuyProducts.now"),
+                            PrimaryButtonView(title: Asset.localizedString(forKey: model.totalPrice ?? 0 > 0 ? "Snabble.Shoppingcart.BuyProducts.now" : "Snabble.Shoppingcart.completePurchase"),
                                               disabled: $disableCheckout, onAction: {
                                 model.startCheckout()
                             })

--- a/UI/Sources/Scanner/CheckoutBar.swift
+++ b/UI/Sources/Scanner/CheckoutBar.swift
@@ -196,6 +196,7 @@ final class CheckoutBar: UIView {
 
         self.itemCountLabel?.text = Asset.localizedString(forKey: "Snabble.Shoppingcart.numberOfItems", arguments: numberOfItems)
         self.checkoutButton?.isEnabled = numberOfItems > 0 && (totalPrice ?? 0) >= 0
+        self.checkoutButton?.setTitle(Asset.localizedString(forKey: totalPrice ?? 0 > 0 ? "Snabble.Shoppingcart.BuyProducts.now" : "Snabble.Shoppingcart.completePurchase"), for: .normal)
 
         self.methodSelector?.updateAvailablePaymentMethods()
         updateViewHierarchy(for: self.methodSelector?.selectedPayment?.method)


### PR DESCRIPTION
Ist der Einkaufswert 0€ oder weniger wird der Titel von "Jetzt bezahlen" auf "Einkauf abschließen" geändert. Der Standardtitel ist weiterhin "Jetzt bezahlen".

https://snabble.atlassian.net/browse/APPS-1939